### PR TITLE
Disease-panel-browser.settings.js moved to standard config folder

### DIFF
--- a/src/sites/iva/index.html
+++ b/src/sites/iva/index.html
@@ -73,6 +73,7 @@
     <script defer src="{{ IVA_CONFIG_PATH }}/opencga-gene-view.settings.js"></script>
     <script defer src="{{ IVA_CONFIG_PATH }}/opencga-family-view.settings.js"></script>
     <script defer src="{{ IVA_CONFIG_PATH }}/rga-browser.settings.js"></script>
+    <script defer src="{{ IVA_CONFIG_PATH }}/disease-panel-browser.settings.js"></script>
 
     <!--    <script src="../lib/jsorolla/src/webcomponents/opencga/panels_example.js"></script>-->
     <script src="{{ IVA_CONFIG_PATH }}/tools.js"></script>

--- a/src/sites/iva/iva-app.js
+++ b/src/sites/iva/iva-app.js
@@ -98,9 +98,6 @@ import "../../webcomponents/commons/layouts/custom-welcome.js";
 import "../../webcomponents/clinical/rga/rga-browser.js";
 
 
-// SETTINGS
-import DISEASE_PANEL_BROWSER_SETTINGS from "./conf/disease-panel-browser.settings.js";
-
 class IvaApp extends LitElement {
 
     constructor() {


### PR DESCRIPTION
The config file has been moved to the standard conf position.
Now the object `DISEASE_PANEL_BROWSER_SETTINGS` should be defined as a plain JS object, avoiding the export as an ES module.

@imedina @pamag If Rollup at the current version allows ES modules to be kept outside the bundle, a discussion could be made to evaluate the conversion of all external settings files into ES modules and use a rewriting step in Rollup what would replace `IVA_CONFIG_PATH` in all JS files (not only HTML).

