### PR TITLE
TASK-509: Somatic and Germline Rearrangement browsers are displaying mixed variants

### DIFF
--- a/src/webcomponents/variant/interpretation/variant-interpreter-browser-cancer.js
+++ b/src/webcomponents/variant/interpretation/variant-interpreter-browser-cancer.js
@@ -316,9 +316,9 @@ class VariantInterpreterBrowserCancer extends LitElement {
                             {
                                 id: "variant-file",
                                 title: "VCF File Filter",
-                                visible: () => this.indexedFiles?.length > 1,
+                                visible: () => this.files?.length > 1,
                                 params: {
-                                    files: this.indexedFiles
+                                    files: this.files,
                                 },
                                 tooltip: tooltips.vcfFile,
                             },

--- a/src/webcomponents/variant/interpretation/variant-interpreter-browser-rearrangement.js
+++ b/src/webcomponents/variant/interpretation/variant-interpreter-browser-rearrangement.js
@@ -131,38 +131,6 @@ class VariantInterpreterBrowserRearrangement extends LitElement {
             }
 
             this.callerToFile = {};
-            // 4. 'fileData' query param: fetch non SV files and set init query
-            // this.opencgaSession.opencgaClient.files().search({sampleIds: this.somaticSample.id, study: this.opencgaSession.study.fqn})
-            //     .then(fileResponse => {
-            //         this.files = fileResponse.responses[0].results;
-            //         // Prepare a map from caller to File
-            //         this.callerToFile = {};
-            //         for (const file of this.files) {
-            //             if (file.software?.name) {
-            //                 const softwareName = file.software.name.toLowerCase();
-            //                 this.callerToFile[softwareName] = file;
-            //             }
-            //         }
-
-            //         // Init the default caller INFO filters
-            //         const fileDataFilters = [];
-            //         for (const caller of this._config.filter.callers) {
-            //             if (this.callerToFile[caller.id]) {
-            //                 fileDataFilters.push(this.callerToFile[caller.id].name + ":" + caller.queryString);
-            //             }
-            //         }
-
-            //         this.query = {
-            //             ...this.query,
-            //             fileData: fileDataFilters.join(",")
-            //         };
-
-            //         // NOTE: We need to update the _config to update the dynamic VCF caller filters
-            //         this._config = this.getDefaultConfig();
-            //     })
-            //     .catch(response => {
-            //         console.error("An error occurred fetching sample: ", response);
-            //     });
             if (this.opencgaSession?.study?.internal?.configuration?.clinical?.interpretation?.variantCallers?.length > 0) {
                 // Somatic callers with the right Variant Type and with defined INFO filters
                 const variantCallers = this.opencgaSession.study.internal.configuration.clinical.interpretation.variantCallers
@@ -170,9 +138,6 @@ class VariantInterpreterBrowserRearrangement extends LitElement {
                     .filter(vc => vc.types.includes("BREAKEND"))
                     .filter(vc => vc.dataFilters.findIndex(filter => !filter.source || filter.source === "FILE") !== -1);
 
-                console.log("SOMATIC", this.somatic);
-                console.log("All callers: ", this.opencgaSession.study.internal.configuration.clinical.interpretation.variantCallers);
-                console.log("Filtered callers: ", variantCallers);
                 // Files matching the selected Variant Callers
                 this.files = this.clinicalAnalysis.files
                     .filter(file => file.format.toUpperCase() === "VCF")

--- a/src/webcomponents/variant/interpretation/variant-interpreter-browser-rearrangement.js
+++ b/src/webcomponents/variant/interpretation/variant-interpreter-browser-rearrangement.js
@@ -326,6 +326,26 @@ class VariantInterpreterBrowserRearrangement extends LitElement {
                         collapsed: false,
                         filters: [
                             {
+                                id: "variant-file",
+                                title: "VCF File Filter",
+                                visible: () => this.files?.length > 1,
+                                params: {
+                                    files: this.files
+                                },
+                                tooltip: tooltips.vcfFile,
+                            },
+                            {
+                                id: "variant-file-info-filter",
+                                title: "Variant Caller File Filter",
+                                visible: () => this.files?.length > 0,
+                                // visible: () => !!this.query.fileData,
+                                params: {
+                                    files: this.files,
+                                    opencgaSession: this.opencgaSession
+                                },
+                                tooltip: tooltips.variantCallerFile,
+                            },
+                            {
                                 id: "region",
                                 title: "Genomic Location",
                                 tooltip: tooltips.region

--- a/src/webcomponents/variant/interpretation/variant-interpreter-browser-rearrangement.js
+++ b/src/webcomponents/variant/interpretation/variant-interpreter-browser-rearrangement.js
@@ -132,37 +132,87 @@ class VariantInterpreterBrowserRearrangement extends LitElement {
 
             this.callerToFile = {};
             // 4. 'fileData' query param: fetch non SV files and set init query
-            this.opencgaSession.opencgaClient.files().search({sampleIds: this.somaticSample.id, study: this.opencgaSession.study.fqn})
-                .then(fileResponse => {
-                    this.files = fileResponse.responses[0].results;
-                    // Prepare a map from caller to File
-                    this.callerToFile = {};
-                    for (const file of this.files) {
-                        if (file.software?.name) {
-                            const softwareName = file.software.name.toLowerCase();
-                            this.callerToFile[softwareName] = file;
-                        }
-                    }
+            // this.opencgaSession.opencgaClient.files().search({sampleIds: this.somaticSample.id, study: this.opencgaSession.study.fqn})
+            //     .then(fileResponse => {
+            //         this.files = fileResponse.responses[0].results;
+            //         // Prepare a map from caller to File
+            //         this.callerToFile = {};
+            //         for (const file of this.files) {
+            //             if (file.software?.name) {
+            //                 const softwareName = file.software.name.toLowerCase();
+            //                 this.callerToFile[softwareName] = file;
+            //             }
+            //         }
 
-                    // Init the default caller INFO filters
+            //         // Init the default caller INFO filters
+            //         const fileDataFilters = [];
+            //         for (const caller of this._config.filter.callers) {
+            //             if (this.callerToFile[caller.id]) {
+            //                 fileDataFilters.push(this.callerToFile[caller.id].name + ":" + caller.queryString);
+            //             }
+            //         }
+
+            //         this.query = {
+            //             ...this.query,
+            //             fileData: fileDataFilters.join(",")
+            //         };
+
+            //         // NOTE: We need to update the _config to update the dynamic VCF caller filters
+            //         this._config = this.getDefaultConfig();
+            //     })
+            //     .catch(response => {
+            //         console.error("An error occurred fetching sample: ", response);
+            //     });
+            if (this.opencgaSession?.study?.internal?.configuration?.clinical?.interpretation?.variantCallers?.length > 0) {
+                // Somatic callers with the right Variant Type and with defined INFO filters
+                const variantCallers = this.opencgaSession.study.internal.configuration.clinical.interpretation.variantCallers
+                    .filter(vc => vc.somatic === this.somatic)
+                    .filter(vc => vc.types.includes("BREAKEND"))
+                    .filter(vc => vc.dataFilters.findIndex(filter => !filter.source || filter.source === "FILE") !== -1);
+
+                console.log("SOMATIC", this.somatic);
+                console.log("All callers: ", this.opencgaSession.study.internal.configuration.clinical.interpretation.variantCallers);
+                console.log("Filtered callers: ", variantCallers);
+                // Files matching the selected Variant Callers
+                this.files = this.clinicalAnalysis.files
+                    .filter(file => file.format.toUpperCase() === "VCF")
+                    .filter(file =>
+                        variantCallers.findIndex(vc => vc.id.toUpperCase() === file.software?.name?.toUpperCase()) !== -1);
+
+                if (this.files?.length > 0) {
                     const fileDataFilters = [];
-                    for (const caller of this._config.filter.callers) {
-                        if (this.callerToFile[caller.id]) {
-                            fileDataFilters.push(this.callerToFile[caller.id].name + ":" + caller.queryString);
+                    variantCallers.forEach(vc => {
+                        const filtersWithDefaultValues = vc.dataFilters
+                            .filter(filter => !filter.source || filter.source === "FILE")
+                            .filter(filter => !!filter.defaultValue)
+                            .map(filter => {
+                                // Notice that defaultValue includes the comparator, eg. =, >, ...
+                                return filter.id + (filter.id !== "FILTER" ? filter.defaultValue : "=PASS");
+                            });
+
+                        // Only add this file to the filter if we have at least one default value
+                        if (filtersWithDefaultValues.length > 0) {
+                            // We need to find the file for that caller
+                            const fileId = this.files.find(file => file.software.name === vc.id)?.name;
+                            if (fileId) {
+                                fileDataFilters.push(fileId + ":" + filtersWithDefaultValues.join(";"));
+                            }
                         }
-                    }
+                    });
 
-                    this.query = {
-                        ...this.query,
-                        fileData: fileDataFilters.join(",")
-                    };
+                    // Update query with default 'fileData' parameters
+                    this.query.fileData = fileDataFilters.join(",");
+                } else {
+                    this.files = this.clinicalAnalysis.files
+                        .filter(file => file.format.toUpperCase() === "VCF");
+                }
+            } else {
+                this.files = this.clinicalAnalysis.files
+                    .filter(file => file.format.toUpperCase() === "VCF");
+            }
 
-                    // NOTE: We need to update the _config to update the dynamic VCF caller filters
-                    this._config = this.getDefaultConfig();
-                })
-                .catch(response => {
-                    console.error("An error occurred fetching sample: ", response);
-                });
+            // Create _config again since getDefaultConfig() uses this.files
+            this._config = this.getDefaultConfig();
 
 
             // Add filter to Active Filter's menu
@@ -190,6 +240,16 @@ class VariantInterpreterBrowserRearrangement extends LitElement {
                     query: this.query
                 }
             );
+
+            // Add 'file' filter if 'fileData' exists
+            if (this.files) {
+                const fileNames = this.files.map(f => f.name).join(",");
+                for (const filter of _activeFilterFilters) {
+                    if (filter.query?.fileData && !filter.query?.file) {
+                        filter.query.file = fileNames;
+                    }
+                }
+            }
 
             // Set active filters
             this._config.filter.activeFilters.filters = _activeFilterFilters;


### PR DESCRIPTION
This PR fixes the default query generation of the rearrangements browser, so the `fileData` is added with the correct file.