### PR TITLE
TASK-528 - Duplicated features in Gene Overview Track of GenomeBrowser

### DIFF
--- a/src/genome-browser/renderers/feature-renderer.js
+++ b/src/genome-browser/renderers/feature-renderer.js
@@ -29,6 +29,14 @@ export default class FeatureRenderer extends Renderer {
             //     }
             // }
 
+            // Prevent rendering a feature twice
+            if (options.renderedFeatures) {
+                if (options.renderedFeatures.has(feature.id)) {
+                    return;
+                }
+                options.renderedFeatures.add(feature.id);
+            }
+
             // get feature render configuration
             const color = typeof this.config.color === "function" ? this.config.color(feature) : this.config.color;
             const strokeColor = typeof this.config.strokeColor === "function" ? this.config.strokeColor(feature) : this.config.strokeColor;

--- a/src/genome-browser/renderers/gene-renderer.js
+++ b/src/genome-browser/renderers/gene-renderer.js
@@ -11,12 +11,12 @@ export default class GeneRenderer extends Renderer {
         (features || []).forEach((feature, index) => {
 
             // Prevent rendering a feature twice
-            if (options.renderedFeatures.has(feature.id)) {
-                return;
+            if (options.renderedFeatures) {
+                if (options.renderedFeatures.has(feature.id)) {
+                    return;
+                }
+                options.renderedFeatures.add(feature.id);
             }
-
-            // Add this feature to the list of rendered features
-            options.renderedFeatures.add(feature.id);
 
             const geneColor = this.getValueFromConfig("geneColor", [feature]);
             const geneLabel = this.getValueFromConfig("geneLabel", [feature]);


### PR DESCRIPTION
This PR fixes the duplicated features displayed in the Gene Overview Track of Genome Browser.