### PR TITLE
Issue 481

### DIFF
--- a/src/sites/iva/iva-app.js
+++ b/src/sites/iva/iva-app.js
@@ -1474,7 +1474,12 @@ class IvaApp extends LitElement {
 
                 ${this.config.enabledComponents["sampleVariantStatsBrowser"] ? html`
                     <div class="content" id="sampleVariantStatsBrowser">
-                        <sample-variant-stats-browser .opencgaSession="${this.opencgaSession}" .sampleId="${this.sampleId}" .active="${true}"></sample-variant-stats-browser>
+                        <sample-variant-stats-browser
+                            .opencgaSession="${this.opencgaSession}"
+                            .sampleId="${this.sampleId}"
+                            .active="${true}"
+                            .settings="${{...VARIANT_INTERPRETER_SAMPLE_VARIANT_STATS_SETTINGS, showTitle: true}}">
+                        </sample-variant-stats-browser>
                     </div>
                 ` : null}
 

--- a/src/webcomponents/commons/catalog-grid-formatter.js
+++ b/src/webcomponents/commons/catalog-grid-formatter.js
@@ -126,7 +126,7 @@ export default class CatalogGridFormatter {
             } else {
                 results = key ? files.map(file => file?.name) : files;
             }
-            return results.length > 20 ? results.length + " files" : `<ul class="pad-left-15">${results.map(file => `<li>${file}</li>`).join("")}</ul>`;
+            return results.length > 20 ? results.length + " files" : `<ul class="pad-left-15">${results.map(file => `<li class="break-word">${file}</li>`).join("")}</ul>`;
         } else {
             return "-";
         }

--- a/src/webcomponents/sample/sample-grid.js
+++ b/src/webcomponents/sample/sample-grid.js
@@ -371,10 +371,17 @@ export default class SampleGrid extends LitElement {
                                 </a>
                             </li>
                             <li>
-                                <a data-action="interpreter" class="btn force-text-left ${row.attributes.OPENCGA_CLINICAL_ANALYSIS ? "" : "disabled"}"
-                                        href="#interpreter/${this.opencgaSession.project.id}/${this.opencgaSession.study.id}/${row.attributes.OPENCGA_CLINICAL_ANALYSIS?.id}">
-                                    <i class="fas fa-user-md icon-padding" aria-hidden="true"></i> Case Interpreter
-                                </a>
+                                ${row.attributes?.OPENCGA_CLINICAL_ANALYSIS?.length ?
+                                    row.attributes.OPENCGA_CLINICAL_ANALYSIS.map(clinicalAnalysis => `
+                                        <a data-action="interpreter" class="btn force-text-left ${row.attributes.OPENCGA_CLINICAL_ANALYSIS ? "" : "disabled"}"
+                                           href="#interpreter/${this.opencgaSession.project.id}/${this.opencgaSession.study.id}/${clinicalAnalysis.id}">
+                                            <i class="fas fa-user-md icon-padding" aria-hidden="true"></i> Case Interpreter (${clinicalAnalysis.id})
+                                        </a>
+                                    `).join("") :
+                                    `<a data-action="interpreter" class="btn force-text-left disabled" href="#">
+                                        <i class="fas fa-user-md icon-padding" aria-hidden="true"></i> Case Interpreter
+                                    </a>`
+                                }
                             </li>
                             <li role="separator" class="divider"></li>
                             <li>

--- a/src/webcomponents/sample/sample-variant-stats-browser.js
+++ b/src/webcomponents/sample/sample-variant-stats-browser.js
@@ -74,7 +74,7 @@ export default class SampleVariantStatsBrowser extends LitElement {
 
     connectedCallback() {
         super.connectedCallback();
-        this._config = {...this.getDefaultConfig(), ...this.config};
+        this._config = {...this.getDefaultConfig()};
         this.consequenceTypes = SAMPLE_STATS_CONSEQUENCE_TYPES;
     }
 
@@ -132,9 +132,11 @@ export default class SampleVariantStatsBrowser extends LitElement {
 
 
     settingsObserver() {
-        this.config = {...this.getDefaultConfig()};
+        // merging misc 1st level props from settings and then delete useless prop `menu`
+        this._config = {...this.getDefaultConfig(), ...this.settings};
+        delete this._config?.menu;
         if (this.settings?.menu) {
-            this._config.filter = UtilsNew.mergeFiltersAndDetails(this.config?.filter, this.settings);
+            this._config.filter = UtilsNew.mergeFiltersAndDetails(this._config?.filter, this.settings);
         }
         this.requestUpdate();
     }


### PR DESCRIPTION
This PR contains the following fixes in Sample Browser and related components:
- Long filenames now correctly break on multiple lines
- Action dropdown: Case interpreter URL fixed
- Variant Stats Browser from Sample Browser now has the tool header correctly shown