### PR TITLE
TASK-739 - Malformed URL for panel app in disease panel column of case portal grid

### DIFF
--- a/src/webcomponents/commons/catalog-grid-formatter.js
+++ b/src/webcomponents/commons/catalog-grid-formatter.js
@@ -95,7 +95,7 @@ export default class CatalogGridFormatter {
                 if (panel.source?.project?.toUpperCase() === "PANELAPP") {
                     panelHtml += `
                         <div style="margin: 5px 0px">
-                            <a href="${BioinfoUtils.getPanelAppLink(panel.source.id)}/" target="_blank">
+                            <a href="${BioinfoUtils.getPanelAppLink(panel.source.id)}" target="_blank">
                                 ${panel.name} (${panel.source.project} v${panel.source.version})
                             </a>
                         </div>`;


### PR DESCRIPTION
This PR removes a trailing `/` in the panels URL.