### PR TITLE
TASK-425 - Allow cases to lock panels if interpretation contains at least one case panel

### DIFF
--- a/src/webcomponents/clinical/clinical-analysis-update.js
+++ b/src/webcomponents/clinical/clinical-analysis-update.js
@@ -145,7 +145,6 @@ class ClinicalAnalysisUpdate extends LitElement {
     }
 
     onFieldChange(e) {
-        console.log(e.detail);
         switch (e.detail.param) {
             case "locked":
             case "panelLock":
@@ -454,9 +453,14 @@ class ClinicalAnalysisUpdate extends LitElement {
                                         return true;
                                     }
 
-                                    const interpretations = [clinicalAnalysis.interpretation, ...clinicalAnalysis.secondaryInterpretations];
+                                    const interpretations = [
+                                        clinicalAnalysis.interpretation,
+                                        ...clinicalAnalysis.secondaryInterpretations,
+                                    ];
                                     for (const interpretation of interpretations) {
-                                        if (clinicalAnalysis.panels?.length !== interpretation?.panels?.length) {
+                                        // Josemi 20220518 NOTE: interpretations should contain at least one panel from the clinical analysis
+                                        // to enable the disease panels lock switch
+                                        if (!interpretation.panels || interpretation.panels.length < 1) {
                                             return true;
                                         }
                                         for (const interpretationPanel of interpretation.panels) {
@@ -466,10 +470,10 @@ class ClinicalAnalysisUpdate extends LitElement {
                                             }
                                         }
                                     }
+
                                     return false;
-                                    // return !!clinicalAnalysis?.locked;
                                 },
-                            }
+                            },
                         },
                         {
                             title: "Flags",

--- a/src/webcomponents/clinical/clinical-analysis-update.js
+++ b/src/webcomponents/clinical/clinical-analysis-update.js
@@ -447,7 +447,7 @@ class ClinicalAnalysisUpdate extends LitElement {
                             field: "panelLock",
                             type: "toggle-switch",
                             display: {
-                                helpMessage: "All existing interpretations must have the same panels to enable Panel Lock",
+                                helpMessage: "All existing interpretations must contain at least one of the Clinical Analysis panels to enable Disease Panel Lock.",
                                 disabled: clinicalAnalysis => {
                                     if (clinicalAnalysis?.locked) {
                                         return true;


### PR DESCRIPTION
This PR updates the Clinical Analysis form to allow the user to lock disease panels if all existing interpretations contain at least one panel from the clinical analysis.