### PR TITLE
TASK-862 - Transcript filter not filtering transcripts in Interpretation review

### DIFF
--- a/src/webcomponents/variant/interpretation/variant-interpreter-review-primary.js
+++ b/src/webcomponents/variant/interpretation/variant-interpreter-review-primary.js
@@ -63,6 +63,9 @@ export default class VariantInterpreterReviewPrimary extends LitElement {
             mode: {
                 type: String
             },
+            toolId: {
+                type: String,
+            },
             settings: {
                 type: Object,
             },
@@ -120,6 +123,14 @@ export default class VariantInterpreterReviewPrimary extends LitElement {
             this._config.result.grid = {
                 ...this._config.result.grid,
                 ...this.settings.table,
+            };
+        }
+
+        // Check for user configuration
+        if (this.toolId && this.opencgaSession.user?.configs?.IVA?.[this.toolId]?.grid) {
+            this._config.result.grid = {
+                ...this._config.result.grid,
+                ...this.opencgaSession.user.configs.IVA[this.toolId].grid,
             };
         }
 

--- a/src/webcomponents/variant/interpretation/variant-interpreter-review.js
+++ b/src/webcomponents/variant/interpretation/variant-interpreter-review.js
@@ -150,6 +150,7 @@ export default class VariantInterpreterReview extends LitElement {
                                         .clinicalAnalysis="${clinicalAnalysis}"
                                         .clinicalVariants="${variants}"
                                         .active="${active}"
+                                        .toolId="${"variantInterpreterCancerSNV"}"
                                         .gridConfig="${{
                                             somatic: true,
                                             variantTypes: ["SNV", "INDEL"],
@@ -185,6 +186,7 @@ export default class VariantInterpreterReview extends LitElement {
                                     .clinicalAnalysis="${clinicalAnalysis}"
                                     .clinicalVariants="${variants}"
                                     .active="${active}"
+                                    .toolId="${"variantInterpreterCancerCNV"}"
                                     .gridConfig="${{
                                         somatic: true,
                                         variantTypes: ["COPY_NUMBER", "CNV"],
@@ -249,6 +251,7 @@ export default class VariantInterpreterReview extends LitElement {
                                         .clinicalAnalysis="${clinicalAnalysis}"
                                         .clinicalVariants="${variants}"
                                         .active="${active}"
+                                        .toolId="${"variantInterpreterRD"}"
                                         .gridConfig="${{
                                             somatic: false,
                                             variantTypes: ["SNV", "INDEL", "INSERTION", "DELETION"],


### PR DESCRIPTION
This PR fixes a bug in the variant interpretation review: user configuration is not merged into the grid default configuration.