### PR TITLE
TASK-953 - Chromosome panel must display the current chromosome name in Genome Browser

### DIFF
--- a/src/genome-browser/panels/chromosome-panel.js
+++ b/src/genome-browser/panels/chromosome-panel.js
@@ -241,6 +241,7 @@ export default class ChromosomePanel {
             });
             this.chromosomeLength = this.chromosome.size;
             this.pixelBase = (this.width - 40) / this.chromosomeLength;
+            this.setTitle(`Chromosome ${this.chromosome.name.replace("chr", "")}`);
         }
 
         const offset = this.config.offset;


### PR DESCRIPTION
This PR displays the current chromosome name in the panel title section of the chromosome panel.