### PR TITLE
TASK-977 - Genome Browser only displays the proband sample if the case type is family

### DIFF
--- a/src/webcomponents/variant/interpretation/variant-interpreter-browser.js
+++ b/src/webcomponents/variant/interpretation/variant-interpreter-browser.js
@@ -301,6 +301,13 @@ class VariantInterpreterBrowser extends LitElement {
                 id: "genome-browser",
                 name: "Genome Browser (Beta)",
                 render: (clinicalAnalysis, active, opencgaSession) => {
+                    let samples = [];
+                    if (clinicalAnalysis.type.toUpperCase() === "FAMILY") {
+                        samples = clinicalAnalysis.family?.members?.map(m => m.samples[0].id) || [];
+                    } else {
+                        samples = clinicalAnalysis.proband.samples.map(s => s.id);
+                    }
+
                     const featuresOfInterest = [];
                     if (clinicalAnalysis.interpretation.panels.length > 0) {
                         featuresOfInterest.push({
@@ -409,7 +416,7 @@ class VariantInterpreterBrowser extends LitElement {
                                         config: {
                                             title: "Variants",
                                             query: {
-                                                sample: clinicalAnalysis.proband.samples.map(s => s.id).join(","),
+                                                sample: samples.join(","),
                                             },
                                             height: 120,
                                         },

--- a/src/webcomponents/variant/interpretation/variant-interpreter-browser.js
+++ b/src/webcomponents/variant/interpretation/variant-interpreter-browser.js
@@ -418,7 +418,8 @@ class VariantInterpreterBrowser extends LitElement {
                                             query: {
                                                 sample: samples.join(","),
                                             },
-                                            height: 120,
+                                            height: 66 + 40 * samples.length,
+                                            resizable: false,
                                         },
                                     },
                                     ...(clinicalAnalysis.proband?.samples || []).map(sample => ({


### PR DESCRIPTION
This PR fixes the displayed samples in the variant track when the case type is FAMILY.