### PR TITLE
TASK-940 - Sample genotypes and depth are not displayed in lollipop tooltip in Genome Browser

### DIFF
--- a/src/genome-browser/genome-browser-utils.js
+++ b/src/genome-browser/genome-browser-utils.js
@@ -213,10 +213,10 @@ export default class GenomeBrowserUtils {
                 <table style="width:100%;">
                     <thead>
                         <tr>
-                            <th></th>
-                            <th>GT</th>
-                            <th>DP</th>
-                            <th>FILTER</th>
+                            <th style="padding:4px;"></th>
+                            <th style="padding:4px;">GT</th>
+                            <th style="padding:4px;">DP</th>
+                            <th style="padding:4px;">FILTER</th>
                         </tr>
                     </thead>
                     <tbody>
@@ -225,10 +225,10 @@ export default class GenomeBrowserUtils {
                             const file = typeof sample?.fileIndex === "number" ? feature.studies[0].files?.[sample.fileIndex] : null;
                             return `
                                 <tr>
-                                    <td><strong>${name}</strong></td>
-                                    <td>${sample?.data?.[0] || "-"}</td>
-                                    <td>${sample?.data?.[dpIndex] || "-"}</td>
-                                    <td>${file ? file?.data?.["FILTER"] : "-"}</td>
+                                    <td style="padding:4px;"><strong>${name}</strong></td>
+                                    <td style="padding:4px;text-align:center;">${sample?.data?.[0] || "-"}</td>
+                                    <td style="padding:4px;text-align:center;">${sample?.data?.[dpIndex] || "-"}</td>
+                                    <td style="padding:4px;text-align:center;">${file ? file?.data?.["FILTER"] : "-"}</td>
                                 </tr>
                             `;
                         }).join("")}

--- a/src/genome-browser/genome-browser-utils.js
+++ b/src/genome-browser/genome-browser-utils.js
@@ -209,14 +209,14 @@ export default class GenomeBrowserUtils {
         if (samples && samples.length > 0 && feature.studies && feature.studies.length > 0) {
             const dpIndex = feature.studies[0].sampleDataKeys?.findIndex(v => v.toUpperCase() === "DP");
             const samplesInfo = `
-                <div style="height:1px;margin-bottom:4px;margin-top:8px;background-color:#eaeaea;"></div>
+                <div style="margin-bottom:4px;margin-top:4px;">Samples:</div>
                 <table style="width:100%;">
                     <thead>
                         <tr>
-                            <th style="padding:4px;"></th>
-                            <th style="padding:4px;">GT</th>
-                            <th style="padding:4px;">DP</th>
-                            <th style="padding:4px;">FILTER</th>
+                            <th style=""></th>
+                            <th style="padding-left:4px;">GT</th>
+                            <th style="padding-left:4px;">DP</th>
+                            <th style="padding-left:4px;">FILTER</th>
                         </tr>
                     </thead>
                     <tbody>
@@ -225,10 +225,10 @@ export default class GenomeBrowserUtils {
                             const file = typeof sample?.fileIndex === "number" ? feature.studies[0].files?.[sample.fileIndex] : null;
                             return `
                                 <tr>
-                                    <td style="padding:4px;"><strong>${name}</strong></td>
-                                    <td style="padding:4px;text-align:center;">${sample?.data?.[0] || "-"}</td>
-                                    <td style="padding:4px;text-align:center;">${sample?.data?.[dpIndex] || "-"}</td>
-                                    <td style="padding:4px;text-align:center;">${file ? file?.data?.["FILTER"] : "-"}</td>
+                                    <td style=""><strong>${name}</strong></td>
+                                    <td style="padding-left:4px;text-align:center;">${sample?.data?.[0] || "-"}</td>
+                                    <td style="padding-left:4px;text-align:center;">${sample?.data?.[dpIndex] || "-"}</td>
+                                    <td style="padding-left:4px;text-align:center;">${file ? file?.data?.["FILTER"] : "-"}</td>
                                 </tr>
                             `;
                         }).join("")}

--- a/src/genome-browser/genome-browser-utils.js
+++ b/src/genome-browser/genome-browser-utils.js
@@ -202,8 +202,43 @@ export default class GenomeBrowserUtils {
     }
 
     // Variant tooltip text formatter
-    static variantTooltipTextFormatter(feature) {
-        return GenomeBrowserUtils.featureTooltipTextFormatter(feature);
+    static variantTooltipTextFormatter(feature, samples) {
+        let info = GenomeBrowserUtils.featureTooltipTextFormatter(feature);
+
+        // Check for samples
+        if (samples && samples.length > 0 && feature.studies && feature.studies.length > 0) {
+            const dpIndex = feature.studies[0].sampleDataKeys?.findIndex(v => v.toUpperCase() === "DP");
+            const samplesInfo = `
+                <div style="height:1px;margin-bottom:4px;margin-top:8px;background-color:#eaeaea;"></div>
+                <table style="width:100%;">
+                    <thead>
+                        <tr>
+                            <th></th>
+                            <th>GT</th>
+                            <th>DP</th>
+                            <th>FILTER</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        ${samples.map((name, index) => {
+                            const sample = feature.studies[0].samples?.[index];
+                            const file = typeof sample?.fileIndex === "number" ? feature.studies[0].files?.[sample.fileIndex] : null;
+                            return `
+                                <tr>
+                                    <td><strong>${name}</strong></td>
+                                    <td>${sample?.data?.[0] || "-"}</td>
+                                    <td>${sample?.data?.[dpIndex] || "-"}</td>
+                                    <td>${file ? file?.data?.["FILTER"] : "-"}</td>
+                                </tr>
+                            `;
+                        }).join("")}
+                    </tbody>
+                </table>
+            `;
+            info = info + samplesInfo;
+        }
+
+        return info;
     }
 
     // Sample genotype tooltip title formatter

--- a/src/genome-browser/renderers/variant-renderer.js
+++ b/src/genome-browser/renderers/variant-renderer.js
@@ -115,6 +115,7 @@ export default class VariantRenderer extends Renderer {
                     position: {
                         viewport: window,
                         target: "mouse",
+                        adjust: {x: 10, y: 10},
                     },
                     style: {
                         width: true,

--- a/src/genome-browser/renderers/variant-renderer.js
+++ b/src/genome-browser/renderers/variant-renderer.js
@@ -45,9 +45,9 @@ export default class VariantRenderer extends Renderer {
             const center = GenomeBrowserUtils.getFeatureX(start + length / 2, options);
 
             // Get variant information
-            const variantColor = this.getValueFromConfig("variantColor", [feature]);
-            const variantTooltipTitle = this.getValueFromConfig("variantTooltipTitle", [feature]);
-            const variantTooltipText = this.getValueFromConfig("variantTooltipText", [feature]);
+            const variantColor = this.getValueFromConfig("variantColor", [feature, this.config.sampleNames]);
+            const variantTooltipTitle = this.getValueFromConfig("variantTooltipTitle", [feature, this.config.sampleNames]);
+            const variantTooltipText = this.getValueFromConfig("variantTooltipText", [feature, this.config.sampleNames]);
 
             let variantElement = null;
 


### PR DESCRIPTION
This PR fixes the variant tooltip formatter for displaying the samples genotypes and depth.