### PR TITLE
TASK-469 - SVB export variants TSV need all column names without spaces (join words with underscore)

### DIFF
--- a/src/webcomponents/variant/variant-utils.js
+++ b/src/webcomponents/variant/variant-utils.js
@@ -101,7 +101,7 @@ export default class VariantUtils {
         flatFieldList.forEach(f => {
             if ("id" === f) {
                 headerString.push("id");
-                headerString.push("SNP ID");
+                headerString.push("SNP_ID");
             } else if (f.startsWith("cohorts.")) {
                 // Cohorts Variant Browser
                 studyIds.forEach(id => {


### PR DESCRIPTION
This PR fixes the SNP ID column name in the TSV export.