### PR TITLE
TASK-457 - Column sex in individual grid is displayed as 'object Object' when passing an empty object

### DIFF
--- a/src/webcomponents/clinical/clinical-analysis-create.js
+++ b/src/webcomponents/clinical/clinical-analysis-create.js
@@ -551,7 +551,7 @@ export default class ClinicalAnalysisCreate extends LitElement {
                                             render: individual => html`
                                                 <div style="font-weight: bold">${individual.id}</div>
                                                 <div class="help-block">
-                                                    ${individual.sex?.id || individual.sex || "Not specified"} (${individual.karyotypicSex || "Not specified"})
+                                                    ${UtilsNew.isEmpty(individual?.sex) ? "Not specified" : individual.sex?.id || individual.sex} (${individual.karyotypicSex || "Not specified"})
                                                 </div>
                                             `,
                                         },

--- a/src/webcomponents/clinical/obsolete/opencga-clinical-analysis-writer.js
+++ b/src/webcomponents/clinical/obsolete/opencga-clinical-analysis-writer.js
@@ -22,6 +22,8 @@ import OpencgaCatalogUtils from "../../../core/clients/opencga/opencga-catalog-u
 import "../filters/clinical-priority-filter.js";
 import NotificationUtils from "../../commons/utils/notification-utils.js";
 
+// Rodiel 2022-06-22 NOTE: DEPRECATED
+// Use clinical-analysis-create & clinical-analysis-update
 export default class OpencgaClinicalAnalysisWriter extends LitElement {
 
     constructor() {

--- a/src/webcomponents/individual/individual-grid.js
+++ b/src/webcomponents/individual/individual-grid.js
@@ -340,7 +340,7 @@ export default class IndividualGrid extends LitElement {
     }
 
     sexFormatter(value, row) {
-        let sexHtml = `<span>${row.sex?.id || row.sex}</span>`;
+        let sexHtml = `<span>${UtilsNew.isEmpty(row?.sex) ? "Not specified" : row.sex?.id || row.sex}</span>`;
         if (row.karyotypicSex) {
             sexHtml += ` (${row.karyotypicSex?.id || row.karyotypicSex})`;
         }

--- a/src/webcomponents/individual/qc/individual-qc-inferred-sex.js
+++ b/src/webcomponents/individual/qc/individual-qc-inferred-sex.js
@@ -153,15 +153,16 @@ export default class IndividualQcInferredSex extends LitElement {
                     <tbody>
                         ${this.individuals.map(individual => {
                             const inferredSex = individual?.qualityControl?.inferredSexReports[0];
+                            const hasSameSex = individual.karyotypicSex === inferredSex?.inferredKaryotypicSex;
                             return html`
                                 <tr>
                                     <td>
                                         <label>${individual.id}</label>
                                     </td>
                                     <td>${individual?.qualityControl?.sampleId ?? "N/A"}</td>
-                                    <td>${individual.sex}</td>
+                                    <td>${UtilsNew.isEmpty(individual?.sex) ? "Not specified" : individual.sex?.id || individual.sex}</td>
                                     <td>
-                                        <span style="color: ${!inferredSex || individual.karyotypicSex === inferredSex?.inferredKaryotypicSex ? "black" : "red"}">
+                                        <span style="color: ${!inferredSex || hasSameSex ? "black" : "red"}">
                                             ${individual.karyotypicSex}
                                         </span>
                                     </td>
@@ -169,7 +170,7 @@ export default class IndividualQcInferredSex extends LitElement {
                                         <td>${inferredSex.values.ratioX.toFixed(4)}</td>
                                         <td>${inferredSex.values.ratioY.toFixed(4)}</td>
                                         <td>
-                                            <span style="color: ${individual.karyotypicSex === inferredSex.inferredKaryotypicSex ? "black" : "red"}">
+                                            <span style="color: ${hasSameSex ? "black" : "red"}">
                                                 ${inferredSex.inferredKaryotypicSex || "-"}
                                             </span>
                                         </td>

--- a/src/webcomponents/variant/interpretation/variant-interpreter-grid-formatter.js
+++ b/src/webcomponents/variant/interpretation/variant-interpreter-grid-formatter.js
@@ -562,7 +562,7 @@ export default class VariantInterpreterGridFormatter {
             if (ca.type === "FAMILY") {
                 // we need to find the sex of each member of the family
                 const individual = ca.family.members.find(m => m.samples[0].id === sampleEntry.sampleId);
-                sex = individual.sex;
+                sex = UtilsNew.isEmpty(individual?.sex) ? "Not specified" : individual.sex?.id || individual.sex;
             } else {
                 sex = ca?.proband?.sex !== "UNKOWN" ? ca.proband.sex : "";
             }


### PR DESCRIPTION
This PR resolved when individual.sex is empty