### PR TITLE
TASK-1104 - Split screen on genome browser

### DIFF
--- a/src/genome-browser/genome-browser.js
+++ b/src/genome-browser/genome-browser.js
@@ -557,11 +557,15 @@ export default class GenomeBrowser {
 
     // Track management
     addOverviewTrack(track) {
-        this.overviewTrackListPanel.addTrack(track);
+        if (this.overviewTrackListPanel) {
+            this.overviewTrackListPanel.addTrack(track);
+        }
     }
 
     addOverviewTracks(tracks) {
-        this.overviewTrackListPanel.addTracks(tracks);
+        if (this.overviewTrackListPanel) {
+            this.overviewTrackListPanel.addTracks(tracks);
+        }
     }
 
     addTrack(track) {

--- a/src/genome-browser/genome-browser.js
+++ b/src/genome-browser/genome-browser.js
@@ -195,6 +195,11 @@ export default class GenomeBrowser {
             overviewPanelVisible: this.config.overviewPanelVisible,
             featuresOfInterest: this.config.featuresOfInterest || [],
             featuresOfInterestTitle: this.config.featuresOfInterestTitle,
+            geneSearchVisible: this.config.navigationPanelGeneSearchVisible,
+            regionSearchVisible: this.config.navigationPanelRegionSearchVisible,
+            historyControlsVisible: this.config.navigationPanelHistoryControlsVisible,
+            zoomControlsVisible: this.config.navigationPanelZoomControlsVisible,
+            positionControlsVisible: this.config.navigationPanelPositionControlsVisible,
         });
 
         // Register event listeners
@@ -610,6 +615,11 @@ export default class GenomeBrowser {
             navigationPanelVisible: true,
             navigationPanelQuickSearchResultFn: null,
             navigationPanelQuickSearchDisplayKey: "name",
+            navigationPanelHistoryControlsVisible: true,
+            navigationPanelZoomControlsVisible: true,
+            navigationPanelPositionControlsVisible: true,
+            navigationPanelGeneSearchVisible: true,
+            navigationPanelRegionSearchVisible: true,
 
             // Status panel configuration
             statusPanelVisible: true,

--- a/src/genome-browser/panels/navigation-bar.js
+++ b/src/genome-browser/panels/navigation-bar.js
@@ -36,15 +36,17 @@ export default class NavigationBar {
         const template = UtilsNew.renderHTML(`
             <div id="${this.prefix}" style="display:flex;flex-wrap:wrap;gap:4px;">
                 <!-- Region history -->
-                <button id="${this.prefix}RegionHistoryRestore" class="btn btn-default btn-sm">
-                    <i class="fa fa-redo"></i>
-                </button>
-                <div title="Region history" class="dropdown" style="display:inline-block;">
-                    <button type="button" id="${this.prefix}RegionHistoryButton" class="btn btn-default btn-sm dropdown-toggle" data-toggle="dropdown">
-                        <i class="fa fa-history"></i>
-                        <span class="caret"></span>
+                <div id="${this.prefix}HistoryControls">
+                    <button id="${this.prefix}RegionHistoryRestore" class="btn btn-default btn-sm">
+                        <i class="fa fa-redo"></i>
                     </button>
-                    <ul id="${this.prefix}RegionHistoryMenu" class="dropdown-menu"></ul>
+                    <div title="Region history" class="dropdown" style="display:inline-block;">
+                        <button type="button" id="${this.prefix}RegionHistoryButton" class="btn btn-default btn-sm dropdown-toggle" data-toggle="dropdown">
+                            <i class="fa fa-history"></i>
+                            <span class="caret"></span>
+                        </button>
+                        <ul id="${this.prefix}RegionHistoryMenu" class="dropdown-menu"></ul>
+                    </div>
                 </div>
                 
                 <!-- Panels buttons -->
@@ -60,29 +62,25 @@ export default class NavigationBar {
                     </button>
                 </div>
 
-                <!-- Zoom control -->
-                <button title="Minimum window size" id="${this.prefix}ZoomMinButton" class="btn btn-default btn-sm" style="display:none;">
-                    <span>Min</span>
-                </button>
-                <button title="Decrease window size" id="${this.prefix}ZoomOutButton" class="btn btn-default btn-sm">
-                    <span class="fa fa-search-minus"></span>
-                </button>
-                <div class="" style="display:inline-block;">
-                    <div class="" style="padding-top:7px;padding-bottom:7px;">
-                        <input type="range" id="${this.prefix}ZoomRange" min="0" max="100" />
+                <!-- Zoom controls -->
+                <div id="${this.prefix}ZoomControls" style="display:flex;flex-wrap:wrap;gap:4px;">
+                    <button title="Decrease window size" id="${this.prefix}ZoomOutButton" class="btn btn-default btn-sm">
+                        <span class="fa fa-search-minus"></span>
+                    </button>
+                    <div class="" style="display:inline-block;">
+                        <div class="" style="padding-top:7px;padding-bottom:7px;">
+                            <input type="range" id="${this.prefix}ZoomRange" min="0" max="100" />
+                        </div>
                     </div>
-                </div>
-                <button title="Increase window size" id="${this.prefix}ZoomInButton" class="btn btn-default btn-sm">
-                    <span class="fa fa-search-plus"></span>
-                </button>
-                <button title="Maximum window size" id="${this.prefix}ZoomMaxButton" class="btn btn-default btn-sm" style="display:none;">
-                    <span>Max</span>
-                </button>
+                    <button title="Increase window size" id="${this.prefix}ZoomInButton" class="btn btn-default btn-sm">
+                        <span class="fa fa-search-plus"></span>
+                    </button>
 
-                <!-- Window size input -->
-                <div id="${this.prefix}WindowSizeForm" title="Window size (Nucleotides)" class="input-group input-group-sm" style="margin:0px;">
-                    <input id="${this.prefix}WindowSizeInput" class="form-control input-sm" style="max-width:60px;" />
-                    <span class="input-group-addon">nts</span>
+                    <!-- Window size input -->
+                    <div id="${this.prefix}WindowSizeForm" title="Window size (Nucleotides)" class="input-group input-group-sm" style="margin:0px;">
+                        <input id="${this.prefix}WindowSizeInput" class="form-control input-sm" style="max-width:60px;" />
+                        <span class="input-group-addon">nts</span>
+                    </div>
                 </div>
 
                 <!-- Features of interest -->
@@ -112,8 +110,8 @@ export default class NavigationBar {
                     </div>
                 </div>
 
-                <!-- Region controls -->
-                <div class="btn-group" style="display:inline-block">
+                <!-- Position controls -->
+                <div id="${this.prefix}PositionControls" class="btn-group" style="display:inline-block">
                     <button id="${this.prefix}MoveFurtherLeftButton" class="btn btn-default btn-sm">
                         <i class="fa fa-angle-double-left"></i>
                     </button>
@@ -163,6 +161,7 @@ export default class NavigationBar {
         this.elements.overviewButton = this.div.querySelector(`button#${this.prefix}OverviewButton`);
 
         // Zooming controls
+        this.elements.zoomControls = this.div.querySelector(`div#${this.prefix}ZoomControls`);
         this.elements.zoomRange = this.div.querySelector(`input#${this.prefix}ZoomRange`);
         this.elements.zoomOutButton = this.div.querySelector(`button#${this.prefix}ZoomOutButton`);
         this.elements.zoomInButton = this.div.querySelector(`button#${this.prefix}ZoomInButton`);
@@ -176,11 +175,13 @@ export default class NavigationBar {
         this.elements.regionSubmit = this.div.querySelector(`button#${this.prefix}RegionSubmit`);
 
         // Region history buttons
+        this.elements.historyControls = this.div.querySelector(`div#${this.prefix}HistoryControls`);
         this.elements.regionHistoryRestore = this.div.querySelector(`button#${this.prefix}RegionHistoryRestore`);
         this.elements.regionHistoryMenu = this.div.querySelector(`ul#${this.prefix}RegionHistoryMenu`);
         this.elements.regionHistoryButton = this.div.querySelector(`div#${this.prefix}RegionHistoryButton`);
 
         // Position controls
+        this.elements.positionControls = this.div.querySelector(`div#${this.prefix}PositionControls`);
         this.elements.moveFurtherLeftButton = this.div.querySelector(`button#${this.prefix}MoveFurtherLeftButton`);
         this.elements.moveFurtherRightButton = this.div.querySelector(`button#${this.prefix}MoveFurtherRightButton`);
         this.elements.moveLeftButton = this.div.querySelector(`button#${this.prefix}MoveLeftButton`);
@@ -214,6 +215,26 @@ export default class NavigationBar {
             if (!this.config.overviewPanelVisible) {
                 this.elements.overviewButton.style.display = "none";
             }
+        }
+
+        if (!this.config.historyControlsVisible) {
+            this.elements.historyControls.style.display = "none";
+        }
+
+        if (!this.config.positionControlsVisible) {
+            this.elements.positionControls.style.display = "none";
+        }
+
+        if (!this.config.zoomControlsVisible) {
+            this.elements.zoomControls.style.display = "none";
+        }
+
+        if (!this.config.regionSearchVisible) {
+            this.elements.regionForm.style.display = "none";
+        }
+
+        if (!this.config.geneSearchVisible) {
+            this.elements.searchForm.style.display = "none";
         }
 
         // Fill features of interest dropdown
@@ -530,6 +551,11 @@ export default class NavigationBar {
             width: 100,
             featuresOfInterest: [],
             featuresOfInterestTitle: "Features of Interest",
+            historyControlsVisible: true,
+            zoomControlsVisible: true,
+            positionControlsVisible: true,
+            geneSearchVisible: true,
+            regionSearchVisible: true,
         };
     }
 

--- a/src/webcomponents/commons/view/detail-tabs.js
+++ b/src/webcomponents/commons/view/detail-tabs.js
@@ -93,6 +93,15 @@ export default class DetailTabs extends LitElement {
         this.requestUpdate();
     }
 
+    renderTitle() {
+        const title = typeof this._config.title === "function" ? this._config.title(this.data) : this._config.title + " " + (this.data?.id || "");
+        return html`
+            <div class="panel ${this._config?.display?.titleClass}" style="${this._config?.display?.titleStyle}">
+                <h3 class="break-word">${title}</h3>
+            </div>
+        `;
+    }
+
     renderTabTitle() {
         return html`
             ${this._config.items.length && this._config.items.map(item => {
@@ -134,14 +143,7 @@ export default class DetailTabs extends LitElement {
         const align = this._config?.display?.align || "";
 
         return html`
-            ${this._config.title ?
-                html`
-                    <div class="panel ${this._config?.display?.titleClass}" style="${this._config?.display?.titleStyle}">
-                        <h3 class="break-word">&nbsp;${this._config.title} ${this.data?.id}</h3>
-                    </div>` :
-                null
-            }
-
+            ${this._config.title ? this.renderTitle() : null}
             <div class="detail-tabs">
                 <!-- TABS -->
                 ${this.mode === DetailTabs.TABS_MODE ? html`

--- a/src/webcomponents/variant/interpretation/variant-interpreter-browser-rearrangement.js
+++ b/src/webcomponents/variant/interpretation/variant-interpreter-browser-rearrangement.js
@@ -17,6 +17,7 @@
 import {LitElement, html} from "lit";
 import UtilsNew from "../../../core/utilsNew.js";
 import "./variant-interpreter-browser-template.js";
+import "../../visualization/split-genome-browser.js";
 
 class VariantInterpreterBrowserRearrangement extends LitElement {
 
@@ -48,6 +49,9 @@ class VariantInterpreterBrowserRearrangement extends LitElement {
             cellbaseClient: {
                 type: Object
             },
+            active: {
+                type: Boolean,
+            },
             settings: {
                 type: Object
             }
@@ -72,6 +76,11 @@ class VariantInterpreterBrowserRearrangement extends LitElement {
         if (changedProperties.has("clinicalAnalysis")) {
             this.clinicalAnalysisObserver();
         }
+
+        if (changedProperties.has("active")) {
+            this._config = this.getDefaultConfig();
+        }
+
         super.update(changedProperties);
     }
 
@@ -389,102 +398,55 @@ class VariantInterpreterBrowserRearrangement extends LitElement {
                     }
                 },
                 detail: {
-                    title: "Selected Variant:",
+                    title: variants => {
+                        return `Selected Variants: ${variants[0].id} - ${variants[1].id}`;
+                    },
                     showTitle: true,
                     items: [
                         {
-                            id: "annotationSummary",
-                            name: "Summary",
+                            id: "browser",
+                            name: "Rearrangements Browser",
                             active: true,
-                            render: variant => html`
-                                <cellbase-variant-annotation-summary
-                                    .variantAnnotation="${variant.annotation}"
-                                    .consequenceTypes="${SAMPLE_STATS_CONSEQUENCE_TYPES}"
-                                    .proteinSubstitutionScores="${PROTEIN_SUBSTITUTION_SCORE}"
-                                    .assembly=${this.opencgaSession.project.organism.assembly}>
-                                </cellbase-variant-annotation-summary>
+                            render: variants => html`
+                                <split-genome-browser
+                                    .opencgaSession="${this.opencgaSession}"
+                                    .regions="${variants}"
+                                    ?active="${this.active}"
+                                    .tracks="${[
+                                        {
+                                            type: "gene",
+                                            config: {},
+                                        },
+                                        {
+                                            type: "opencga-variant",
+                                            config: {
+                                                title: "Variants",
+                                                query: {
+                                                    sample: this.clinicalAnalysis.proband.samples.map(s => s.id).join(","),
+                                                },
+                                                height: 120,
+                                            },
+                                        },
+                                        ...(this.clinicalAnalysis.proband?.samples || []).map(sample => ({
+                                            type: "opencga-alignment",
+                                            config: {
+                                                title: `Alignments - ${sample.id}`,
+                                                sample: sample.id,
+                                            },
+                                        })),
+                                    ]}"
+                                    .config="${{
+                                        cellBaseClient: this.cellbaseClient,
+                                        karyotypePanelVisible: false,
+                                        overviewPanelVisible: false,
+                                    }}">
+                                </split-genome-browser>
                             `,
                         },
-                        {
-                            id: "annotationConsType",
-                            name: "Consequence Type",
-                            render: (variant, active) => html`
-                                <variant-consequence-type-view
-                                    .consequenceTypes="${variant.annotation.consequenceTypes}"
-                                    .active="${active}">
-                                </variant-consequence-type-view>
-                            `,
-                        },
-                        {
-                            id: "annotationPropFreq",
-                            name: "Population Frequencies",
-                            render: (variant, active) => html`
-                                <cellbase-population-frequency-grid
-                                    .populationFrequencies="${variant.annotation.populationFrequencies}"
-                                    .active="${active}">
-                                </cellbase-population-frequency-grid>
-                            `,
-                        },
-                        {
-                            id: "annotationClinical",
-                            name: "Clinical",
-                            render: variant => html`
-                                <variant-annotation-clinical-view
-                                    .traitAssociation="${variant.annotation.traitAssociation}"
-                                    .geneTraitAssociation="${variant.annotation.geneTraitAssociation}">
-                                </variant-annotation-clinical-view>
-                            `,
-                        },
-                        {
-                            id: "fileMetrics",
-                            name: "File Metrics",
-                            render: (variant, active, opencgaSession) => html`
-                                <opencga-variant-file-metrics
-                                    .opencgaSession="${opencgaSession}"
-                                    .variant="${variant}"
-                                    .files="${this.clinicalAnalysis}">
-                                </opencga-variant-file-metrics>
-                            `,
-                        },
-                        {
-                            id: "cohortStats",
-                            name: "Cohort Stats",
-                            render: (variant, active, opencgaSession) => html`
-                                <variant-cohort-stats
-                                    .opencgaSession="${opencgaSession}"
-                                    .variant="${variant}"
-                                    .active="${active}">
-                                </variant-cohort-stats>
-                            `,
-                        },
-                        {
-                            id: "samples",
-                            name: "Samples",
-                            render: (variant, active, opencgaSession) => html`
-                                <variant-samples
-                                    .opencgaSession="${opencgaSession}"
-                                    .variantId="${variant.id}"
-                                    .active="${active}">
-                                </variant-samples>
-                            `,
-                        },
-                        {
-                            id: "beacon",
-                            name: "Beacon",
-                            render: (variant, active, opencgaSession) => html`
-                                <variant-beacon-network
-                                    .variant="${variant.id}"
-                                    .assembly="${opencgaSession.project.organism.assembly}"
-                                    .config="${this.beaconConfig}"
-                                    .active="${active}">
-                                </variant-beacon-network>
-                            `,
-                        }
                     ]
                 }
             },
-            aggregation: {
-            }
+            aggregation: {},
         };
     }
 

--- a/src/webcomponents/variant/interpretation/variant-interpreter-browser-rearrangement.js
+++ b/src/webcomponents/variant/interpretation/variant-interpreter-browser-rearrangement.js
@@ -439,6 +439,9 @@ class VariantInterpreterBrowserRearrangement extends LitElement {
                                         cellBaseClient: this.cellbaseClient,
                                         karyotypePanelVisible: false,
                                         overviewPanelVisible: false,
+                                        navigationPanelHistoryControlsVisible: false,
+                                        navigationPanelGeneSearchVisible: false,
+                                        navigationPanelRegionSearchVisible: false,
                                     }}">
                                 </split-genome-browser>
                             `,

--- a/src/webcomponents/variant/interpretation/variant-interpreter-browser.js
+++ b/src/webcomponents/variant/interpretation/variant-interpreter-browser.js
@@ -358,6 +358,7 @@ class VariantInterpreterBrowser extends LitElement {
                                         .clinicalAnalysis="${clinicalAnalysis}"
                                         .cellbaseClient="${this.cellbaseClient}"
                                         .settings="${this.settings.browsers["REARRANGEMENT"]}"
+                                        ?active="${active}"
                                         @clinicalAnalysisUpdate="${this.onClinicalAnalysisUpdate}">
                                     </variant-interpreter-browser-rearrangement>
                                 </div>
@@ -404,6 +405,7 @@ class VariantInterpreterBrowser extends LitElement {
                                         .somatic="${false}"
                                         .cellbaseClient="${this.cellbaseClient}"
                                         .settings="${this.settings.browsers["REARRANGEMENT"]}"
+                                        ?active="${active}"
                                         @clinicalAnalysisUpdate="${this.onClinicalAnalysisUpdate}">
                                     </variant-interpreter-browser-rearrangement>
                                 </div>

--- a/src/webcomponents/variant/interpretation/variant-interpreter-detail.js
+++ b/src/webcomponents/variant/interpretation/variant-interpreter-detail.js
@@ -167,7 +167,7 @@ export default class VariantInterpreterDetail extends LitElement {
                 {
                     id: "fileMetrics",
                     name: "File Metrics",
-                    render: (variant, active, opencgaSession) => html`
+                    render: (variant, _active, opencgaSession) => html`
                         <opencga-variant-file-metrics
                             .opencgaSession="${opencgaSession}"
                             .variant="${variant}"

--- a/src/webcomponents/variant/interpretation/variant-interpreter-detail.js
+++ b/src/webcomponents/variant/interpretation/variant-interpreter-detail.js
@@ -64,8 +64,11 @@ export default class VariantInterpreterDetail extends LitElement {
         this._config = this.getDefaultConfig();
     }
 
-    firstUpdated(_changedProperties) {
-        this._config = {...this.getDefaultConfig(), ...this.config};
+    firstUpdated() {
+        this._config = {
+            ...this.getDefaultConfig(),
+            ...this.config,
+        };
     }
 
     update(changedProperties) {
@@ -74,7 +77,10 @@ export default class VariantInterpreterDetail extends LitElement {
         }
 
         if (changedProperties.has("config")) {
-            this._config = {...this.getDefaultConfig(), ...this.config};
+            this._config = {
+                ...this.getDefaultConfig(),
+                ...this.config,
+            };
         }
 
         super.update(changedProperties);
@@ -119,72 +125,66 @@ export default class VariantInterpreterDetail extends LitElement {
                     id: "annotationSummary",
                     name: "Summary",
                     active: true,
-                    render: variant => {
-                        return html`
-                            <cellbase-variant-annotation-summary
-                                    .variantAnnotation="${variant.annotation}"
-                                    .consequenceTypes="${CONSEQUENCE_TYPES}"
-                                    .proteinSubstitutionScores="${PROTEIN_SUBSTITUTION_SCORE}"
-                                      .assembly=${this.opencgaSession.project.organism.assembly}>
-                            </cellbase-variant-annotation-summary>`;
-                    }
+                    render: variant => html`
+                        <cellbase-variant-annotation-summary
+                            .variantAnnotation="${variant.annotation}"
+                            .consequenceTypes="${CONSEQUENCE_TYPES}"
+                            .proteinSubstitutionScores="${PROTEIN_SUBSTITUTION_SCORE}"
+                            .assembly="${this.opencgaSession.project.organism.assembly}">
+                        </cellbase-variant-annotation-summary>
+                    `,
                 },
                 {
                     id: "annotationConsType",
                     name: "Consequence Type",
-                    render: (variant, active) => {
-                        return html`
-                            <variant-consequence-type-view
-                                    .consequenceTypes="${variant.annotation.consequenceTypes}"
-                                    .active="${active}">
-                            </variant-consequence-type-view>`;
-                    }
+                    render: (variant, active) => html`
+                        <variant-consequence-type-view
+                            .consequenceTypes="${variant.annotation.consequenceTypes}"
+                            .active="${active}">
+                        </variant-consequence-type-view>
+                    `,
                 },
                 {
                     id: "annotationPropFreq",
                     name: "Population Frequencies",
-                    render: (variant, active) => {
-                        return html`
-                            <cellbase-population-frequency-grid
-                                    .populationFrequencies="${variant.annotation.populationFrequencies}"
-                                    .active="${active}">
-                            </cellbase-population-frequency-grid>`;
-                    }
+                    render: (variant, active) => html`
+                        <cellbase-population-frequency-grid
+                            .populationFrequencies="${variant.annotation.populationFrequencies}"
+                            .active="${active}">
+                        </cellbase-population-frequency-grid>
+                    `,
                 },
                 {
                     id: "annotationClinical",
                     name: "Clinical",
-                    render: variant => {
-                        return html`
-                            <variant-annotation-clinical-view
-                                    .traitAssociation="${variant.annotation.traitAssociation}"
-                                    .geneTraitAssociation="${variant.annotation.geneTraitAssociation}">
-                            </variant-annotation-clinical-view>`;
-                    }
+                    render: variant => html`
+                        <variant-annotation-clinical-view
+                            .traitAssociation="${variant.annotation.traitAssociation}"
+                            .geneTraitAssociation="${variant.annotation.geneTraitAssociation}">
+                        </variant-annotation-clinical-view>
+                    `,
                 },
                 {
                     id: "fileMetrics",
                     name: "File Metrics",
-                    render: (variant, active, opencgaSession) => {
-                        return html`
-                            <opencga-variant-file-metrics
-                                    .opencgaSession="${opencgaSession}"
-                                    .variant="${variant}"
-                                    .files="${this.clinicalAnalysis}">
-                            </opencga-variant-file-metrics>`;
-                    }
+                    render: (variant, active, opencgaSession) => html`
+                        <opencga-variant-file-metrics
+                            .opencgaSession="${opencgaSession}"
+                            .variant="${variant}"
+                            .files="${this.clinicalAnalysis}">
+                        </opencga-variant-file-metrics>
+                    `,
                 },
                 {
                     id: "cohortStats",
                     name: "Cohort Stats",
-                    render: (variant, active, opencgaSession) => {
-                        return html`
-                            <variant-cohort-stats
-                                    .opencgaSession="${opencgaSession}"
-                                    .variantId="${variant.id}"
-                                    .active="${active}">
-                            </variant-cohort-stats>`;
-                    }
+                    render: (variant, active, opencgaSession) => html`
+                        <variant-cohort-stats
+                            .opencgaSession="${opencgaSession}"
+                            .variantId="${variant.id}"
+                            .active="${active}">
+                        </variant-cohort-stats>
+                    `,
                 },
                 {
                     id: "samples",
@@ -194,26 +194,27 @@ export default class VariantInterpreterDetail extends LitElement {
                             .opencgaSession="${opencgaSession}"
                             .variantId="${variant.id}"
                             .active="${active}">
-                        </variant-samples>`,
+                        </variant-samples>
+                    `,
                 },
                 {
                     id: "beacon",
                     name: "Beacon",
-                    render: (variant, active, opencgaSession) => {
-                        return html`
-                            <variant-beacon-network
-                                    .variant="${variant.id}"
-                                    .assembly="${opencgaSession.project.organism.assembly}"
-                                    .config="${this.beaconConfig}"
-                                    .active="${active}">
-                            </variant-beacon-network>`;
-                    }
+                    render: (variant, active, opencgaSession) => html`
+                        <variant-beacon-network
+                            .variant="${variant.id}"
+                            .assembly="${opencgaSession.project.organism.assembly}"
+                            .config="${this.beaconConfig}"
+                            .active="${active}">
+                        </variant-beacon-network>
+                    `,
                 },
                 {
                     id: "json-view",
                     name: "JSON Data",
                     render: (variant, active) => html`
-                                <json-viewer .data="${variant}" .active="${active}"></json-viewer>`,
+                        <json-viewer .data="${variant}" .active="${active}"></json-viewer>
+                    `,
                 }
                 // TODO Think about the possibility of allowing plugins here
                 // {

--- a/src/webcomponents/variant/interpretation/variant-interpreter-detail.js
+++ b/src/webcomponents/variant/interpretation/variant-interpreter-detail.js
@@ -93,7 +93,7 @@ export default class VariantInterpreterDetail extends LitElement {
     }
 
     render() {
-        if (!this.variant?.annotation) {
+        if (!this.variant?.annotation && !Array.isArray(this.variant)) {
             return;
         }
 

--- a/src/webcomponents/visualization/split-genome-browser.js
+++ b/src/webcomponents/visualization/split-genome-browser.js
@@ -1,0 +1,62 @@
+import {LitElement, html} from "lit";
+import "./genome-browser.js";
+
+export default class SplitGenomeBrowser extends LitElement {
+
+    createRenderRoot() {
+        return this;
+    }
+
+    static get properties() {
+        return {
+            opencgaSession: {
+                type: Object,
+            },
+            regions: {
+                type: Array,
+            },
+            species: {
+                type: String,
+            },
+            tracks: {
+                type: Array,
+            },
+            active: {
+                type: Boolean,
+            },
+            config: {
+                type: Object,
+            },
+        };
+    }
+
+    render() {
+        if (!this.opencgaSession) {
+            return null;
+        }
+
+        return html`
+            <div class="row">
+                ${this.regions.map(region => html`
+                    <div class="col-md-6">
+                        <genome-browser
+                            .opencgaSession="${this.opencgaSession}"
+                            .region="${region}"
+                            .active="${this.active}"
+                            .species="${this.species}"
+                            .tracks="${this.tracks}"
+                            .config="${this.config}">
+                        </genome-browser>
+                    </div>
+                `)}
+            </div>
+        `;
+    }
+
+    getDefaultConfig() {
+        return {};
+    }
+
+}
+
+customElements.define("split-genome-browser", SplitGenomeBrowser);


### PR DESCRIPTION
This PR adds a new component called `split-genome-browser` for visualizing multiple regions in different Genome Browsers instances at the same time, and uses this component for visualizing rearrangements in the Variant Rearrangement Browser.