### PR TITLE
TASK-1231 - Variant Track must display all samples without scrolling

### DIFF
--- a/src/genome-browser/tracks/opencga-variant-track.js
+++ b/src/genome-browser/tracks/opencga-variant-track.js
@@ -165,14 +165,10 @@ export default class OpenCGAVariantTrack extends FeatureTrack {
     getDefaultConfig() {
         return {
             title: "",
-            height: 200,
-            maxHeight: 300,
-            resizable: true,
-            dataAdapter: null,
+            height: 0,
+            resizable: false,
             opencgaClient: null,
             opencgaStudy: "",
-            // opencgaSamples: [],
-            // opencgaFiles: [],
             query: null,
             histogramMinRegionSize: 300000000,
             histogramInterval: 10000,

--- a/src/webcomponents/variant/interpretation/variant-interpreter-browser.js
+++ b/src/webcomponents/variant/interpretation/variant-interpreter-browser.js
@@ -192,7 +192,6 @@ class VariantInterpreterBrowser extends LitElement {
                         query: {
                             sample: this.clinicalAnalysis.proband.samples.map(s => s.id).join(","),
                         },
-                        height: 120,
                     },
                 },
                 ...(this.clinicalAnalysis.proband?.samples || []).map(sample => ({


### PR DESCRIPTION
This PR fixes a bug in the OpenCGA Variants track of Genome Browser that causes not all samples are visible by default on this track without scrolling.