### PR TITLE
TASK-1444 - Detailed section in Genome Browser is not visible

### DIFF
--- a/src/genome-browser/genome-browser.js
+++ b/src/genome-browser/genome-browser.js
@@ -73,7 +73,7 @@ export default class GenomeBrowser {
                     <li id="${this.prefix}Karyotype" class="list-group-item" style="display:none;"></li>
                     <li id="${this.prefix}Chromosome" class="list-group-item" style="display:none;"></li>
                     <li id="${this.prefix}Region" class="list-group-item" style="display:none;"></li>
-                    <li id="${this.prefix}Tracks" class="list-group-item" style="display:none;"></li>
+                    <li id="${this.prefix}Tracks" class="list-group-item"></li>
                 </ul>
                 <div id="${this.prefix}Status" class="panel-footer" style="display:none;"></div>
             </div>


### PR DESCRIPTION
This PR adds a fix for the Genome Browser: the detailed section is hidden and is never displayed.