### PR TITLE
TASK-1439 - Changing a tab in variant interpreter details hides all interpreter browsers

### DIFF
--- a/src/webcomponents/commons/view/detail-tabs.js
+++ b/src/webcomponents/commons/view/detail-tabs.js
@@ -103,7 +103,9 @@ export default class DetailTabs extends LitElement {
 
     changeTab(e) {
         this._activeTab = e.currentTarget.dataset.id;
-        LitUtils.dispatchCustomEvent(this, "activeTabChange", this._activeTab);
+        LitUtils.dispatchCustomEvent(this, "activeTabChange", this._activeTab, null, null, {
+            bubbles: false,
+        });
         this.requestUpdate();
     }
 


### PR DESCRIPTION
This PR fixes a bug in the `detail-tabs` component that hides all interpreter browsers when a tab in the detail section is changed.