### PR TITLE
TASK-1533 - Wrong filter name when filtering by sample ID

### DIFF
--- a/src/webcomponents/commons/opencga-active-filters.js
+++ b/src/webcomponents/commons/opencga-active-filters.js
@@ -584,7 +584,7 @@ export default class OpencgaActiveFilters extends LitElement {
                 "region": "Region",
                 "gene": "Gene",
                 "genotype": "Sample Genotype",
-                "sample": "Sample Genotype",
+                "sample": "Sample ID",
                 "maf": "Cohort Stat MAF",
                 "cohortStatsAlt": "Cohort ALT Stats",
                 "xref": "XRef",

--- a/src/webcomponents/commons/opencga-active-filters.js
+++ b/src/webcomponents/commons/opencga-active-filters.js
@@ -577,40 +577,6 @@ export default class OpencgaActiveFilters extends LitElement {
         return UtilsNew.isNotUndefined(item.items);
     }
 
-    getDefaultConfig() {
-        return {
-            searchButtonText: "SEARCH",
-            alias: {
-                "region": "Region",
-                "gene": "Gene",
-                "genotype": "Sample Genotype",
-                "sample": "Sample ID",
-                "maf": "Cohort Stat MAF",
-                "cohortStatsAlt": "Cohort ALT Stats",
-                "xref": "XRef",
-                "panel": "Disease Panel",
-                "file": "Files",
-                "qual": "QUAL",
-                "filter": "FILTER",
-                "annot-xref": "XRef",
-                "biotype": "Biotype",
-                "ct": "Consequence Type",
-                "annot-ct": "Consequence Type",
-                "alternate_frequency": "Population ALT Frequency",
-                "annot-functional-score": "CADD",
-                "proteinSubstitution": "Protein Substitution",
-                "annot-go": "GO",
-                "annot-hpo": "HPO"
-            },
-            complexFields: [],
-            hiddenFields: [],
-            lockedFields: [],
-            save: {
-                ignoreParams: ["study", "sample", "sampleData", "file", "fileData"]
-            }
-        };
-    }
-
     render() {
         return html`
             ${this.facetActive ? html`
@@ -859,6 +825,40 @@ export default class OpencgaActiveFilters extends LitElement {
                 </div>
             </div>
         `;
+    }
+
+    getDefaultConfig() {
+        return {
+            searchButtonText: "SEARCH",
+            alias: {
+                "region": "Region",
+                "gene": "Gene",
+                "genotype": "Sample Genotype",
+                "sample": "Sample ID",
+                "maf": "Cohort Stat MAF",
+                "cohortStatsAlt": "Cohort ALT Stats",
+                "xref": "XRef",
+                "panel": "Disease Panel",
+                "file": "Files",
+                "qual": "QUAL",
+                "filter": "FILTER",
+                "annot-xref": "XRef",
+                "biotype": "Biotype",
+                "ct": "Consequence Type",
+                "annot-ct": "Consequence Type",
+                "alternate_frequency": "Population ALT Frequency",
+                "annot-functional-score": "CADD",
+                "proteinSubstitution": "Protein Substitution",
+                "annot-go": "GO",
+                "annot-hpo": "HPO"
+            },
+            complexFields: [],
+            hiddenFields: [],
+            lockedFields: [],
+            save: {
+                ignoreParams: ["study", "sample", "sampleData", "file", "fileData"]
+            }
+        };
     }
 
 }

--- a/src/webcomponents/variant/interpretation/variant-interpreter-browser-cancer.js
+++ b/src/webcomponents/variant/interpretation/variant-interpreter-browser-cancer.js
@@ -284,9 +284,8 @@ class VariantInterpreterBrowserCancer extends LitElement {
                 activeFilters: {
                     alias: {
                         // Example:
-                        // "region": "Region",
-                        // "gene": "Gene",
-                        "ct": "Consequence Types"
+                        "ct": "Consequence Types",
+                        "sample": "Sample Genotype"
                     },
                     complexFields: [
                         {id: "sample", separator: ";"},

--- a/src/webcomponents/variant/interpretation/variant-interpreter-browser-cnv.js
+++ b/src/webcomponents/variant/interpretation/variant-interpreter-browser-cnv.js
@@ -247,10 +247,8 @@ class VariantInterpreterBrowserCNV extends LitElement {
                 searchButtonText: "Search",
                 activeFilters: {
                     alias: {
-                        // Example:
-                        // "region": "Region",
-                        // "gene": "Gene",
-                        "ct": "Consequence Types"
+                        "ct": "Consequence Types",
+                        "sample": "Sample Genotype"
                     },
                     complexFields: [
                         {id: "sample", separator: ";"},

--- a/src/webcomponents/variant/interpretation/variant-interpreter-browser-rd.js
+++ b/src/webcomponents/variant/interpretation/variant-interpreter-browser-rd.js
@@ -298,10 +298,8 @@ class VariantInterpreterBrowserRd extends LitElement {
                 searchButtonText: "Search",
                 activeFilters: {
                     alias: {
-                        // Example:
-                        // "region": "Region",
-                        // "gene": "Gene",
-                        "ct": "Consequence Types"
+                        "ct": "Consequence Types",
+                        "sample": "Sample Genotype"
                     },
                     complexFields: [
                         {id: "sample", separator: ";"},


### PR DESCRIPTION
This PR fixes the sample ID filter name in the `opencga-active-filters` component.