### PR TITLE
TASK-1468 - Individual Browser phenotype and disease filters: search does not restring results

### DIFF
--- a/src/webcomponents/commons/filters/catalog-distinct-autocomplete.js
+++ b/src/webcomponents/commons/filters/catalog-distinct-autocomplete.js
@@ -76,6 +76,7 @@ export default class CatalogDistinctAutocomplete extends LitElement {
     getDefaultConfig() {
         return {
             limit: 10,
+            disablePagination: true,
             source: (params, success, failure) => {
                 const RESOURCES = {
                     "SAMPLE": this.opencgaSession.opencgaClient.samples(),

--- a/src/webcomponents/commons/filters/catalog-distinct-autocomplete.js
+++ b/src/webcomponents/commons/filters/catalog-distinct-autocomplete.js
@@ -101,7 +101,15 @@ export default class CatalogDistinctAutocomplete extends LitElement {
 
                 // The exact name of the field, see the example above about 'disorders' and 'disorders.id'
                 RESOURCES[this.resource].distinct(this.distinctField, filters)
-                    .then(response => success(response))
+                    .then(response => {
+                        if (params?.data?.term) {
+                            const term = params.data.term.toUpperCase();
+                            response.responses[0].results = response.responses[0].results.filter(item => {
+                                return item.toUpperCase().includes(term);
+                            });
+                        }
+                        success(response);
+                    })
                     .catch(error => failure(error));
 
             },

--- a/src/webcomponents/commons/forms/select-token-filter.js
+++ b/src/webcomponents/commons/forms/select-token-filter.js
@@ -76,7 +76,7 @@ export default class SelectTokenFilter extends LitElement {
                     return {
                         results: this._config.preprocessResults(restResponse.getResults()),
                         pagination: {
-                            more: (_params.page * this._config.limit) < restResponse.getResponse().numMatches
+                            more: !this._config.disablePagination && (_params.page * this._config.limit) < restResponse.getResponse().numMatches,
                         }
                     };
                 }
@@ -192,6 +192,7 @@ export default class SelectTokenFilter extends LitElement {
         return {
             separator: [","],
             limit: 10,
+            disablePagination: false,
             minimumInputLength: 0,
             maxItems: 0,
             placeholder: "Start typing",


### PR DESCRIPTION
This PR allows to restring search in catalog autocomplete filters like phenotype and disease filters.