### PR TITLE
TASK-1590 - "Assign to" value is missing in case overview tabs

### DIFF
--- a/src/webcomponents/clinical/clinical-analysis-view.js
+++ b/src/webcomponents/clinical/clinical-analysis-view.js
@@ -219,9 +219,9 @@ export default class ClinicalAnalysisView extends LitElement {
                         },
                         {
                             title: "Assigned To",
-                            field: "analyst.assignee",
+                            field: "analyst.id",
                             display: {
-                                visible: !this._config?.hiddenFields?.includes("analyst.assignee"),
+                                visible: !this._config?.hiddenFields?.includes("analyst.assignee") && !this._config?.hiddenFields?.includes("analyst.id"),
                             },
                         },
                         {


### PR DESCRIPTION
This PR fixes displaying the analyst Id in the clinical analysis view.