### PR TITLE
TASK-1620 - 'Assigned To' field is empty when exporting clinical analysis

### DIFF
--- a/src/webcomponents/clinical/clinical-analysis-grid.js
+++ b/src/webcomponents/clinical/clinical-analysis-grid.js
@@ -677,25 +677,24 @@ export default class ClinicalAnalysisGrid extends LitElement {
 
     download(restResponse, format = "JSON") {
         const result = restResponse.getResults();
-        let dataString;
         if (result) {
             // Check if user clicked in Tab or JSON format
-            if (format?.toLowerCase() === "tab") {
-                dataString = [
+            if (format?.toUpperCase() === "TAB") {
+                const dataString = [
                     ["Case ID", "Proband ID", "Family (#members)", "Disorder", "Type", "Interpretation IDs", "Status", "Priority", "Assigned To", "Creation Date"].join("\t"),
-                    ...result.map(_ => [
-                        _.id,
-                        _.proband.id,
-                        _.family?.id && _.family?.members.length ? `${_.family.id} (${_.family.members.length})` : "-",
-                        _?.disorder?.id ?? "-",
-                        _.type ?? "-",
-                        _.interpretation?.id ? `${_.interpretation.id}(primary)${_.secondaryInterpretations.length ? (", " + _.secondaryInterpretations.map(s => s.id).join(", ")) : ""}` : "-",
-                        _.status?.id ?? "-",
-                        _.priority?.id ?? "-",
-                        _.analyst?.id ?? "-",
-                        _.creationDate ? CatalogGridFormatter.dateFormatter(_.creationDate) : "-"
-                    ].join("\t"))];
-
+                    ...result.map(row => [
+                        row.id,
+                        row.proband.id,
+                        row.family?.id && row.family?.members?.length ? `${row.family.id} (${row.family.members.length})` : "-",
+                        row.disorder?.id ?? "-",
+                        row.type ?? "-",
+                        row.interpretation?.id ? [`${row.interpretation.id} (primary)`, ...(row.secondaryInterpretations || []).map(s => s.id)].join(", ") : "-",
+                        row.status?.id ?? "-",
+                        row.priority?.id ?? "-",
+                        row.analyst?.id ?? "-",
+                        row.creationDate ? CatalogGridFormatter.dateFormatter(row.creationDate) : "-"
+                    ].join("\t")),
+                ];
                 UtilsNew.downloadData([dataString.join("\n")], result[0].id + ".tsv", "text/plain");
             } else {
                 const json = JSON.stringify(result, null, "\t");

--- a/src/webcomponents/clinical/clinical-analysis-grid.js
+++ b/src/webcomponents/clinical/clinical-analysis-grid.js
@@ -692,7 +692,7 @@ export default class ClinicalAnalysisGrid extends LitElement {
                         _.interpretation?.id ? `${_.interpretation.id}(primary)${_.secondaryInterpretations.length ? (", " + _.secondaryInterpretations.map(s => s.id).join(", ")) : ""}` : "-",
                         _.status?.id ?? "-",
                         _.priority?.id ?? "-",
-                        _.analyst?.assignee ?? "-",
+                        _.analyst?.id ?? "-",
                         _.creationDate ? CatalogGridFormatter.dateFormatter(_.creationDate) : "-"
                     ].join("\t"))];
 


### PR DESCRIPTION
This PR fixes the `Asigned To` field in the exported TSV from the clinical analysis grid.