### PR TITLE
TASK-1461 - Settings in variant tables in report

### DIFF
--- a/src/webcomponents/commons/view/detail-tabs.js
+++ b/src/webcomponents/commons/view/detail-tabs.js
@@ -85,7 +85,7 @@ export default class DetailTabs extends LitElement {
         };
 
         // Set default active tab
-        if (!this._activeTab) {
+        if (this._config?.items?.length > 0 && !this._activeTab) {
             const activeIndex = this._config.items.findIndex(item => item.active);
             if (activeIndex >= 0) {
                 this._activeTab = this._config.items[activeIndex].id;

--- a/src/webcomponents/variant/interpretation/case-steiner-report.js
+++ b/src/webcomponents/variant/interpretation/case-steiner-report.js
@@ -325,6 +325,8 @@ class CaseSteinerReport extends LitElement {
             showReview: false,
             showActions: false,
             showSettings: false,
+            showColumns: false,
+            showDownload: false,
 
             showSelectCheckbox: false,
             multiSelection: false,
@@ -344,6 +346,11 @@ class CaseSteinerReport extends LitElement {
             },
             evidences: {
                 showSelectCheckbox: false,
+            },
+            toolbar: {
+                showColumns: false,
+                showDownload: false,
+                showExport: false,
             },
         };
 

--- a/src/webcomponents/variant/interpretation/case-steiner-report.js
+++ b/src/webcomponents/variant/interpretation/case-steiner-report.js
@@ -318,6 +318,7 @@ class CaseSteinerReport extends LitElement {
             detailView: true,
             showReview: false,
             showActions: false,
+            showSettings: false,
 
             showSelectCheckbox: false,
             multiSelection: false,
@@ -335,9 +336,8 @@ class CaseSteinerReport extends LitElement {
                 qual: 30,
                 dp: 20,
             },
-            // populationFrequencies: ["1kG_phase3:ALL", "GNOMAD_GENOMES:ALL", "GNOMAD_EXOMES:ALL", "UK10K:ALL", "GONL:ALL", "ESP6500:ALL", "EXAC:ALL"]
             evidences: {
-                showSelectCheckbox: true,
+                showSelectCheckbox: false,
             },
         };
 

--- a/src/webcomponents/variant/interpretation/case-steiner-report.js
+++ b/src/webcomponents/variant/interpretation/case-steiner-report.js
@@ -53,6 +53,12 @@ class CaseSteinerReport extends LitElement {
     }
 
     _init() {
+        this.gridTypes = {
+            snv: "variantInterpreterCancerSNV",
+            cnv: "variantInterpreterCancerCNV",
+            rearrangements: "variantInterpreterRearrangement",
+        };
+
         this.callersInfo = {
             "caveman": {type: "Substitutions", group: "somatic", rank: 1},
             "pindel": {type: "Indels", group: "somatic", rank: 2},
@@ -701,6 +707,7 @@ class CaseSteinerReport extends LitElement {
                                             .clinicalVariants="${filteredVariants}"
                                             .review="${false}"
                                             .config="${{
+                                                ...(this.opencgaSession?.user?.configs?.IVA?.[this.gridTypes.snv]?.grid || {}),
                                                 ...defaultGridConfig,
                                                 somatic: false,
                                                 variantTypes: ["SNV", "INDEL", "INSERTION", "DELETION"],
@@ -731,7 +738,10 @@ class CaseSteinerReport extends LitElement {
                                             .clinicalAnalysis="${this.clinicalAnalysis}"
                                             .clinicalVariants="${filteredVariants}"
                                             .review="${false}"
-                                            .config="${defaultGridConfig}">
+                                            .config="${{
+                                                ...(this.opencgaSession?.user?.configs?.IVA?.[this.gridTypes.rearrangements]?.grid || {}),
+                                                ...defaultGridConfig,
+                                            }}">
                                         </variant-interpreter-rearrangement-grid>
                                     `: null;
                                 },
@@ -774,6 +784,7 @@ class CaseSteinerReport extends LitElement {
                                             .clinicalVariants="${filteredVariants}"
                                             .review="${false}"
                                             .config="${{
+                                                ...(this.opencgaSession?.user?.configs?.IVA?.[this.gridTypes.snv]?.grid || {}),
                                                 ...defaultGridConfig,
                                                 somatic: true,
                                                 variantTypes: ["SNV", "INDEL"],
@@ -804,7 +815,10 @@ class CaseSteinerReport extends LitElement {
                                             .clinicalAnalysis="${this.clinicalAnalysis}"
                                             .clinicalVariants="${filteredVariants}"
                                             .review="${false}"
-                                            .config="${defaultGridConfig}">
+                                            .config="${{
+                                                ...(this.opencgaSession?.user?.configs?.IVA?.[this.gridTypes.rearrangements]?.grid || {}),
+                                                ...defaultGridConfig,
+                                            }}">
                                         </variant-interpreter-rearrangement-grid>
                                     ` : null;
                                 },
@@ -833,6 +847,7 @@ class CaseSteinerReport extends LitElement {
                                             .clinicalVariants="${filteredVariants}"
                                             .review="${false}"
                                             .config="${{
+                                                ...(this.opencgaSession?.user?.configs?.IVA?.[this.gridTypes.cnv]?.grid || {}),
                                                 ...defaultGridConfig,
                                                 somatic: true,
                                                 variantTypes: ["COPY_NUMBER", "CNV"],

--- a/src/webcomponents/variant/interpretation/variant-interpreter-rearrangement-grid.js
+++ b/src/webcomponents/variant/interpretation/variant-interpreter-rearrangement-grid.js
@@ -112,12 +112,13 @@ export default class VariantInterpreterRearrangementGrid extends LitElement {
                 ...this.config,
             };
             this.gridCommons = new GridCommons(this.gridId, this, this._config);
-            const defaultColumns = this._createDefaultColumns();
             this.toolbarConfig = {
                 ...this._config,
                 ...this._config.toolbar, // it comes from external settings
                 resource: "CLINICAL_VARIANT",
             };
+            this.requestUpdate();
+            this.renderVariants();
         }
     }
 
@@ -1048,15 +1049,18 @@ export default class VariantInterpreterRearrangementGrid extends LitElement {
     }
 
     getRightToolbar() {
-        return [
-            {
-                render: () => html`
-                    <button type="button" class="btn btn-default btn-sm" aria-haspopup="true" aria-expanded="false" @click="${e => this.onConfigClick(e)}">
-                        <i class="fas fa-cog icon-padding"></i> Settings ...
-                    </button>
-                `,
-            }
-        ];
+        if (this._config?.showSettings) {
+            return [
+                {
+                    render: () => html`
+                        <button type="button" class="btn btn-default btn-sm" aria-haspopup="true" aria-expanded="false" @click="${e => this.onConfigClick(e)}">
+                            <i class="fas fa-cog icon-padding"></i> Settings ...
+                        </button>
+                    `,
+                }
+            ];
+        }
+        return [];
     }
 
     render() {
@@ -1142,6 +1146,7 @@ export default class VariantInterpreterRearrangementGrid extends LitElement {
             pageSize: 10,
             pageList: [5, 10, 25],
             showExport: true,
+            showSettings: true,
             detailView: true,
             showReview: true,
             showSelectCheckbox: false,


### PR DESCRIPTION
This PR hides all settings buttons of the grids in the report view and merges the grid configuration with the user saved configuration used in the variant interpreter browser.