### PR TITLE
TASK-1501 - GB link is still visible in the Actions menu after disabling GB in the interpretation settings

### DIFF
--- a/src/webcomponents/variant/interpretation/variant-interpreter-browser-template.js
+++ b/src/webcomponents/variant/interpretation/variant-interpreter-browser-template.js
@@ -136,6 +136,11 @@ class VariantInterpreterBrowserTemplate extends LitElement {
             };
         }
 
+        // Check to hide the genome browser link
+        if (this.settings?.hideGenomeBrowser) {
+            this._config.filter.result.grid.showGenomeBrowserLink = false;
+        }
+
         // Add copy.execute functions
         if (this._config.filter.result.grid?.copies?.length > 0) {
             for (const copy of this._config.filter.result.grid?.copies) {

--- a/src/webcomponents/variant/interpretation/variant-interpreter-browser.js
+++ b/src/webcomponents/variant/interpretation/variant-interpreter-browser.js
@@ -301,7 +301,10 @@ class VariantInterpreterBrowser extends LitElement {
                                     .opencgaSession="${opencgaSession}"
                                     .clinicalAnalysis="${clinicalAnalysis}"
                                     .cellbaseClient="${this.cellbaseClient}"
-                                    .settings="${this.settings.browsers["RD"]}"
+                                    .settings="${{
+                                        ...this.settings.browsers["RD"],
+                                        hideGenomeBrowser: !!this.settings.hideGenomeBrowser,
+                                    }}"
                                     @clinicalAnalysisUpdate="${this.onClinicalAnalysisUpdate}"
                                     @genomeBrowserRegionChange="${e => this.onGenomeBrowserRegionChange(e)}"
                                     @samplechange="${this.onSampleChange}">
@@ -327,7 +330,10 @@ class VariantInterpreterBrowser extends LitElement {
                                         .opencgaSession="${opencgaSession}"
                                         .clinicalAnalysis="${clinicalAnalysis}"
                                         .cellbaseClient="${this.cellbaseClient}"
-                                        .settings="${this.settings.browsers["CANCER_SNV"]}"
+                                        .settings="${{
+                                            ...this.settings.browsers["CANCER_SNV"],
+                                            hideGenomeBrowser: !!this.settings.hideGenomeBrowser,
+                                        }}"
                                         @genomeBrowserRegionChange="${e => this.onGenomeBrowserRegionChange(e)}"
                                         @clinicalAnalysisUpdate="${this.onClinicalAnalysisUpdate}">
                                     </variant-interpreter-browser-cancer>
@@ -353,7 +359,10 @@ class VariantInterpreterBrowser extends LitElement {
                                         .clinicalAnalysis="${clinicalAnalysis}"
                                         .query="${this.query}"
                                         .cellbaseClient="${this.cellbaseClient}"
-                                        .settings="${this.settings.browsers["CANCER_CNV"]}"
+                                        .settings="${{
+                                            ...this.settings.browsers["CANCER_CNV"],
+                                            hideGenomeBrowser: !!this.settings.hideGenomeBrowser,
+                                        }}"
                                         @genomeBrowserRegionChange="${e => this.onGenomeBrowserRegionChange(e)}"
                                         @clinicalAnalysisUpdate="${this.onClinicalAnalysisUpdate}">
                                     </variant-interpreter-browser-cnv>
@@ -377,7 +386,10 @@ class VariantInterpreterBrowser extends LitElement {
                                         .opencgaSession="${opencgaSession}"
                                         .clinicalAnalysis="${clinicalAnalysis}"
                                         .cellbaseClient="${this.cellbaseClient}"
-                                        .settings="${this.settings.browsers["REARRANGEMENT"]}"
+                                        .settings="${{
+                                            ...this.settings.browsers["REARRANGEMENT"],
+                                            hideGenomeBrowser: !!this.settings.hideGenomeBrowser,
+                                        }}"
                                         ?active="${active}"
                                         @clinicalAnalysisUpdate="${this.onClinicalAnalysisUpdate}">
                                     </variant-interpreter-browser-rearrangement>
@@ -402,7 +414,10 @@ class VariantInterpreterBrowser extends LitElement {
                                             .opencgaSession="${opencgaSession}"
                                             .clinicalAnalysis="${clinicalAnalysis}"
                                             .cellbaseClient="${this.cellbaseClient}"
-                                            .settings="${this._config}"
+                                            .settings="${{
+                                                ...this._config,
+                                                hideGenomeBrowser: !!this.settings.hideGenomeBrowser,
+                                            }}"
                                             @clinicalAnalysisUpdate="${this.onClinicalAnalysisUpdate}"
                                             @genomeBrowserRegionChange="${e => this.onGenomeBrowserRegionChange(e)}"
                                             @samplechange="${this.onSampleChange}">
@@ -425,7 +440,10 @@ class VariantInterpreterBrowser extends LitElement {
                                         .clinicalAnalysis="${clinicalAnalysis}"
                                         .somatic="${false}"
                                         .cellbaseClient="${this.cellbaseClient}"
-                                        .settings="${this.settings.browsers["REARRANGEMENT"]}"
+                                        .settings="${{
+                                            ...this.settings.browsers["REARRANGEMENT"],
+                                            hideGenomeBrowser: !!this.settings.hideGenomeBrowser,
+                                        }}"
                                         ?active="${active}"
                                         @clinicalAnalysisUpdate="${this.onClinicalAnalysisUpdate}">
                                     </variant-interpreter-browser-rearrangement>

--- a/src/webcomponents/variant/interpretation/variant-interpreter-grid.js
+++ b/src/webcomponents/variant/interpretation/variant-interpreter-grid.js
@@ -843,12 +843,14 @@ export default class VariantInterpreterGrid extends LitElement {
                                         </a>
                                     </li>
                                     <li role="separator" class="divider"></li>
-                                    <li class="dropdown-header">Genome Browser</li>
-                                    <li>
-                                        <a class="btn force-text-left" data-action="genome-browser">
-                                            <i class="fas fa-dna icon-padding" aria-hidden="true"></i>Genome Browser
-                                        </a>
-                                    </li>
+                                    ${this._config.showGenomeBrowserLink ? `
+                                        <li class="dropdown-header">Genome Browser</li>
+                                        <li>
+                                            <a class="btn force-text-left" data-action="genome-browser">
+                                                <i class="fas fa-dna icon-padding" aria-hidden="true"></i>Genome Browser
+                                            </a>
+                                        </li>
+                                    ` : ""}
                                     <li class="dropdown-header">External Genome Browsers</li>
                                     <li>
                                         <a target="_blank" class="btn force-text-left"
@@ -1524,6 +1526,7 @@ export default class VariantInterpreterGrid extends LitElement {
             showActions: true,
             showEditReview: true,
             showType: true,
+            showGenomeBrowserLink: true,
             multiSelection: false,
             nucleotideGenotype: true,
             alleleStringLengthMax: 10,

--- a/src/webcomponents/variant/interpretation/variant-interpreter-review-primary.js
+++ b/src/webcomponents/variant/interpretation/variant-interpreter-review-primary.js
@@ -131,6 +131,7 @@ export default class VariantInterpreterReviewPrimary extends LitElement {
             this._config.result.grid = {
                 ...this._config.result.grid,
                 ...this.opencgaSession.user.configs.IVA[this.toolId].grid,
+                showGenomeBrowserLink: false,
             };
         }
 
@@ -326,6 +327,7 @@ export default class VariantInterpreterReviewPrimary extends LitElement {
                     detailView: true,
                     showReview: true,
                     showActions: true,
+                    showGenomeBrowserLink: false,
 
                     showSelectCheckbox: true,
                     multiSelection: false,


### PR DESCRIPTION
This PR hides the GB link in the Actions dropdown of the variant interpreter grid when the GB tab is hidden in the variant interpreter browser.