### PR TITLE
TASK-1793 - The export query dialog in sample variant browser has a export type as CSV instead VCF

### DIFF
--- a/src/webcomponents/commons/opencga-export.js
+++ b/src/webcomponents/commons/opencga-export.js
@@ -562,8 +562,8 @@ const client = new OpenCGAClient({
                                     <button type="button" class="btn export-buttons ${classMap({active: this.format === "vep"})}" data-format="vep" @click="${this.changeFormat}">
                                         <i class="fas fa-file-code fa-2x"></i>
                                         <span class="export-buttons-text">Ensembl VEP</span>
-                                    </button>` : null
-                                }
+                                    </button>
+                                ` : null}
                                 <button type="button" class="btn export-buttons ${classMap({active: this.format === "json"})}" data-format="json" @click="${this.changeFormat}">
                                     <i class="fas fa-file-code fa-2x"></i>
                                     <span class="export-buttons-text">JSON</span>

--- a/src/webcomponents/commons/opencga-export.js
+++ b/src/webcomponents/commons/opencga-export.js
@@ -554,9 +554,11 @@ const client = new OpenCGAClient({
                                 <h4 class="export-section-title">Select Output Format</h4>
                                 <button type="button" class="btn export-buttons ${classMap({active: this.format === "tab"})}" data-format="tab" @click="${this.changeFormat}">
                                     <i class="fas fa-table fa-2x"></i>
-                                    <span class="export-buttons-text">${this.config.resource === "VARIANT" ? "VCF" : "CSV"}</span>
+                                    <span class="export-buttons-text">
+                                        ${(this.config.resource === "VARIANT" || this.config.resource === "CLINICAL_VARIANT") ? "VCF" : "CSV"}
+                                    </span>
                                 </button>
-                                ${this.config.resource === "VARIANT" ? html`
+                                ${(this.config.resource === "VARIANT" || this.config.resource === "CLINICAL_VARIANT") ? html`
                                     <button type="button" class="btn export-buttons ${classMap({active: this.format === "vep"})}" data-format="vep" @click="${this.changeFormat}">
                                         <i class="fas fa-file-code fa-2x"></i>
                                         <span class="export-buttons-text">Ensembl VEP</span>


### PR DESCRIPTION
This PR fixes the export types displayed in the export modal of the Sample Variant Browser.