### PR TITLE
TASK-1663 - The Download button from the Case Explorer saves files with information of multiple clinical cases but names the downloaded files using the name of a single clinical case

### DIFF
--- a/src/webcomponents/clinical/clinical-analysis-grid.js
+++ b/src/webcomponents/clinical/clinical-analysis-grid.js
@@ -682,6 +682,8 @@ export default class ClinicalAnalysisGrid extends LitElement {
     download(restResponse, format = "JSON") {
         const result = restResponse.getResults();
         if (result) {
+            const study = this.opencgaSession.study.id;
+            const filename = result.length > 1 ? `clinical-analysis-${study}` : `${result[0].id}-${study}`;
             // Check if user clicked in Tab or JSON format
             if (format?.toUpperCase() === "TAB") {
                 const dataString = [
@@ -699,10 +701,10 @@ export default class ClinicalAnalysisGrid extends LitElement {
                         row.creationDate ? CatalogGridFormatter.dateFormatter(row.creationDate) : "-"
                     ].join("\t")),
                 ];
-                UtilsNew.downloadData([dataString.join("\n")], result[0].id + ".tsv", "text/plain");
+                UtilsNew.downloadData([dataString.join("\n")], filename + ".tsv", "text/plain");
             } else {
                 const json = JSON.stringify(result, null, "\t");
-                UtilsNew.downloadData(json, result[0].id + ".json", "application/json");
+                UtilsNew.downloadData(json, filename + ".json", "application/json");
             }
         } else {
             console.error("Error in result format");


### PR DESCRIPTION
This PR fixes the filename used when downloading the clinical analysis table.