### PR TITLE
TASK-1659 When sample filter in case portal contains more than one item, removing one from the dropdown menu in the active filter tab, remove all and left the grid unresponsive for new searchs

### DIFF
--- a/src/webcomponents/commons/opencga-active-filters.js
+++ b/src/webcomponents/commons/opencga-active-filters.js
@@ -542,10 +542,14 @@ export default class OpencgaActiveFilters extends LitElement {
              * QUICKFIX: `sample` has semicolons and commas both, it needs a custom logic
              */
             if (name === "sample") {
-                filterFields = _queryList[name].split(new RegExp(";"));
+                filterFields = _queryList[name].split(new RegExp("[,;]"));
                 const indexOfValue = filterFields.indexOf(value);
                 filterFields.splice(indexOfValue, 1);
-                _queryList[name] = filterFields.join(";");
+                if (_queryList[name].indexOf(",") !== -1) {
+                    _queryList[name] = filterFields.join(",");
+                } else {
+                    _queryList[name] = filterFields.join(";");
+                }
 
             } else {
                 // Check if the field has been defined as complex


### PR DESCRIPTION
This PR resolved to remove a sample in the filter