### PR TITLE
TASK-1952 - Not able to remove a filter when clicking on the counter badge

### DIFF
--- a/src/webcomponents/commons/opencga-active-filters.js
+++ b/src/webcomponents/commons/opencga-active-filters.js
@@ -521,7 +521,7 @@ export default class OpencgaActiveFilters extends LitElement {
     onQueryFilterDelete(e) {
         const _queryList = Object.assign({}, this.query);
 
-        const {filterName: name, filterValue: value} = e.target.dataset;
+        const {filterName: name, filterValue: value} = e.currentTarget.dataset;
         console.log("onQueryFilterDelete", name, value);
 
         if (UtilsNew.isEmpty(value)) {


### PR DESCRIPTION
This PR fixes the opencga-active-filters component to allow removing a filter when clicking on the counter badge element instead of in the filter button.