### PR TITLE
RGA bugfixes

### DIFF
--- a/src/webcomponents/clinical/rga/rga-browser.js
+++ b/src/webcomponents/clinical/rga/rga-browser.js
@@ -304,7 +304,7 @@ export default class RgaBrowser extends LitElement {
                                     There is a chance that the second variant is a de novo on the same chromosome and therefore that the participant is not a Compounds Heterozygous.</li>
                                     </ul>`,
                                 type: "checkbox",
-                                allowedValues: [{id: 0, name: "No parents"}, {id: 1, name: "One parent"}, {id: 2, name: "Two parents"}]
+                                allowedValues: [/* {id: 0, name: "No parents"},*/{id: 1, name: "One parent"}, {id: 2, name: "Two parents"}]
                             }
                             /* {
                                 id: "probandOnly",

--- a/src/webcomponents/clinical/rga/rga-browser.js
+++ b/src/webcomponents/clinical/rga/rga-browser.js
@@ -374,7 +374,7 @@ export default class RgaBrowser extends LitElement {
                 </div>`;
         }
 
-        if (this.opencgaSession.study?.attributes?.RGA?.status !== "INDEXED") {
+        if (this.opencgaSession.study?.internal?.index?.recessiveGene?.status !== "INDEXED") {
             return html`
                 <div class="guard-page">
                     <i class="fas fa-lock fa-5x"></i>

--- a/src/webcomponents/clinical/rga/rga-gene-view.js
+++ b/src/webcomponents/clinical/rga/rga-gene-view.js
@@ -243,7 +243,7 @@ export default class RgaGeneView extends LitElement {
                 },
                 {
                     title: "Recessive Individuals",
-                    colspan: 6
+                    colspan: 5
                 },
                 {
                     title: "Recessive Variants",
@@ -295,11 +295,11 @@ export default class RgaGeneView extends LitElement {
                     field: "individualStats.singleParent.numCompHet",
                     formatter: value => value > 0 ? value : "-"
                 },
-                {
+                /* {
                     title: "CH - Possible",
                     field: "individualStats.missingParents.numCompHet",
                     formatter: value => value > 0 ? value : "-"
-                },
+                },*/
                 // Recessive Variants
                 {
                     title: "Total",
@@ -408,7 +408,7 @@ export default class RgaGeneView extends LitElement {
                                 "Individuals_DELETION_OVERLAP",
                                 "Individuals_CH_Definite",
                                 "Individuals_CH_Probable",
-                                "Individuals_CH_Possible",
+                                // "Individuals_CH_Possible",
                                 "Variants_Total",
                                 "Variants_HOM",
                                 "Variants_CH"
@@ -420,7 +420,7 @@ export default class RgaGeneView extends LitElement {
                                 _.individualStats.numDelOverlap,
                                 _.individualStats.bothParents.numCompHet,
                                 _.individualStats.singleParent.numCompHet,
-                                _.individualStats.missingParents.numCompHet,
+                                // _.individualStats.missingParents.numCompHet,
                                 _.variantStats.count,
                                 _.variantStats.numHomAlt,
                                 _.variantStats.numCompHet

--- a/src/webcomponents/clinical/rga/rga-individual-family.js
+++ b/src/webcomponents/clinical/rga/rga-individual-family.js
@@ -88,9 +88,14 @@ export default class RgaIndividualFamily extends LitElement {
         if (individual?.attributes?.OPENCGA_CLINICAL_ANALYSIS) {
             const clinicalAnalysis = individual.attributes.OPENCGA_CLINICAL_ANALYSIS?.[0];
             if (clinicalAnalysis) {
-                trio.proband = clinicalAnalysis.family.members.find(m => m.id === clinicalAnalysis.proband.id);
-                trio.father = clinicalAnalysis.family.members.find(m => m.id === trio.proband.father.id);
-                trio.mother = clinicalAnalysis.family.members.find(m => m.id === trio.proband.mother.id);
+                if (clinicalAnalysis?.family?.members?.length) {
+                    trio.proband = clinicalAnalysis.family.members.find(m => m.id === clinicalAnalysis.proband.id);
+                    trio.father = clinicalAnalysis.family.members.find(m => m.id === trio.proband.father.id);
+                    trio.mother = clinicalAnalysis.family.members.find(m => m.id === trio.proband.mother.id);
+                } else {
+                    // in case a Family array is not present, we use the proband (e.g. Cancer studies)
+                    trio.proband = clinicalAnalysis.proband;
+                }
             } else {
                 // NOTE TODO clinicalAnalysis must be defined
                 NotificationUtils.dispatch(this, NotificationUtils.NOTIFY_ERROR, {

--- a/src/webcomponents/clinical/rga/rga-individual-view.js
+++ b/src/webcomponents/clinical/rga/rga-individual-view.js
@@ -176,7 +176,8 @@ export default class RgaIndividualView extends LitElement {
                                 {
                                     individual: individualIds,
                                     study: this.opencgaSession.study.fqn,
-                                    include: "id,proband.id,family.members"
+                                    include: "id,proband.id,family.members",
+                                    limit: params.data.limit,
                                 })
                                 .then(caseResponse => {
                                     // NOTE we don't convert individuals nor clinical data in map first.

--- a/src/webcomponents/clinical/rga/rga-individual-view.js
+++ b/src/webcomponents/clinical/rga/rga-individual-view.js
@@ -176,7 +176,7 @@ export default class RgaIndividualView extends LitElement {
                                 {
                                     individual: individualIds,
                                     study: this.opencgaSession.study.fqn,
-                                    include: "id,proband.id,family.members",
+                                    include: "id,proband.id,proband.samples.id,family.members",
                                     limit: params.data.limit,
                                 })
                                 .then(caseResponse => {

--- a/src/webcomponents/clinical/rga/rga-individual-view.js
+++ b/src/webcomponents/clinical/rga/rga-individual-view.js
@@ -104,7 +104,7 @@ export default class RgaIndividualView extends LitElement {
                 {
 
                     title: "Compound Heterozygous",
-                    field: "ch_def,ch_prob,ch_poss"
+                    field: "ch_def,ch_prob"
                 },
                 {
                     title: "Phenotypes",
@@ -252,7 +252,6 @@ export default class RgaIndividualView extends LitElement {
         });
     }
 
-    // TODO move this into utils class
     formatShowingRows(pageFrom, pageTo, totalRows) {
         const pagedFromFormatted = Number(pageFrom).toLocaleString();
         const pagedToFormatted = Number(pageTo).toLocaleString();
@@ -355,7 +354,7 @@ export default class RgaIndividualView extends LitElement {
                 {
                     title: "Compound Heterozygous",
                     field: "ch",
-                    colspan: 3
+                    colspan: 2
                 },
                 {
                     title: "Phenotypes",
@@ -409,12 +408,12 @@ export default class RgaIndividualView extends LitElement {
                     title: "Probable",
                     field: "ch_prob",
                     formatter: (value, row) => this.getChConfidenceFormatter(row, 1)
-                },
+                }/* ,
                 {
                     title: "Possible",
                     field: "ch_poss",
                     formatter: (value, row) => this.getChConfidenceFormatter(row, 0)
-                }
+                }*/
             ]
         ];
     }
@@ -485,7 +484,7 @@ export default class RgaIndividualView extends LitElement {
                                 "DELETION_OVERLAP",
                                 "CH_Definite",
                                 "CH_Probable",
-                                "CH_Possible",
+                                // "CH_Possible",
                                 "Phenotypes",
                                 "Disorders"
                             ].join("\t"),
@@ -497,7 +496,7 @@ export default class RgaIndividualView extends LitElement {
                                 _.variantStats.numDelOverlap,
                                 this.getChConfidenceFormatter(_, 2),
                                 this.getChConfidenceFormatter(_, 1),
-                                this.getChConfidenceFormatter(_, 0),
+                                // this.getChConfidenceFormatter(_, 0),
                                 _?.phenotypes.length ? _.phenotypes.map(phenotype => phenotype.id).join(",") : "-",
                                 _?.disorders.length ? _.disorders.map(disorder => disorder.id).join(",") : "-"
                             ].join("\t"))];

--- a/src/webcomponents/clinical/rga/rga-individual-view.js
+++ b/src/webcomponents/clinical/rga/rga-individual-view.js
@@ -183,7 +183,7 @@ export default class RgaIndividualView extends LitElement {
                                     // NOTE we don't convert individuals nor clinical data in map first.
                                     rgaIndividualResponse.getResults().forEach(individual => {
                                         for (const clinicalAnalysis of caseResponse.getResults()) {
-                                            if (clinicalAnalysis.family.members.find(member => member.id === individual.id)) {
+                                            if (clinicalAnalysis?.family?.members?.find(member => member.id === individual.id) || clinicalAnalysis.proband.id === individual.id) {
                                                 if (individual?.attributes?.OPENCGA_CLINICAL_ANALYSIS) {
                                                     individual.attributes.OPENCGA_CLINICAL_ANALYSIS.push(clinicalAnalysis);
                                                 } else {

--- a/src/webcomponents/clinical/rga/rga-variant-individual.js
+++ b/src/webcomponents/clinical/rga/rga-variant-individual.js
@@ -143,7 +143,7 @@ export default class RgaVariantIndividual extends LitElement {
                                     // NOTE we don't convert individuals nor clinical data in map first.
                                     rgaIndividualResponse.getResults().forEach(individual => {
                                         for (const clinicalAnalysis of caseResponse.getResults()) {
-                                            if (clinicalAnalysis.family.members.find(member => member.id === individual.id)) {
+                                            if (clinicalAnalysis?.family?.members?.find(member => member.id === individual.id) || clinicalAnalysis.proband.id === individual.id) {
                                                 if (individual?.attributes?.OPENCGA_CLINICAL_ANALYSIS) {
                                                     individual.attributes.OPENCGA_CLINICAL_ANALYSIS.push(clinicalAnalysis);
                                                 } else {

--- a/src/webcomponents/clinical/rga/rga-variant-view.js
+++ b/src/webcomponents/clinical/rga/rga-variant-view.js
@@ -132,11 +132,11 @@ export default class RgaVariantView extends LitElement {
                 {
                     title: "CH - Probable",
                     field: "individualStats.singleParent.numCompHet"
-                },
+                }/* ,
                 {
                     title: "CH - Possible",
                     field: "individualStats.missingParents.numCompHet"
-                }
+                }*/
             ],
             showColumns: true,
             showExport: false,
@@ -256,7 +256,7 @@ export default class RgaVariantView extends LitElement {
                 {
                     title: "Recessive Individuals",
                     field: "",
-                    colspan: 6
+                    colspan: 5
                 }
             ], [
 
@@ -287,11 +287,11 @@ export default class RgaVariantView extends LitElement {
                     field: "individualStats.singleParent.numCompHet",
                     formatter: value => value > 0 ? value : "-"
                 },
-                {
+                /* {
                     title: "CH - Possible",
                     field: "individualStats.missingParents.numCompHet",
                     formatter: value => value > 0 ? value : "-"
-                }
+                }*/
 
                 // {
                 //     title: "Individuals",
@@ -582,7 +582,7 @@ export default class RgaVariantView extends LitElement {
                                 "Individuals_DELETION_OVERLAP",
                                 "Individuals_CH_Definite",
                                 "Individuals_CH_Probable",
-                                "Individuals_CH_Possible"
+                                // "Individuals_CH_Possible"
                             ].join("\t"),
                             ...results.map(_ => [
                                 _.id,
@@ -596,7 +596,7 @@ export default class RgaVariantView extends LitElement {
                                 _.individualStats?.numDelOverlap,
                                 _.individualStats?.bothParents?.numCompHet,
                                 _.individualStats?.singleParent?.numCompHet,
-                                _.individualStats?.missingParents?.numCompHet
+                                // _.individualStats?.missingParents?.numCompHet
                             ].join("\t"))];
                         UtilsNew.downloadData(dataString, "rga_variants_" + this.opencgaSession.study.id + ".tsv", "text/plain");
                     } else {


### PR DESCRIPTION
This PR includes:
- fix on the attribute to check to assess the RGA index status of a study. KMDS-1395
- bugfixes for handling Cancer Studies that miss the family in Clinical Analysis. KMDS-1396 
- Remove "Possible CH" in all the table. KMDS-1378
- bugfix in pagination in Individual View. KMDS-1350