### PR TITLE
TASK-1918 - Job overview view does not parse correctly the Input parameters for `analysis/variant/sample/stats/run` and leaves it as [object Object]

### DIFF
--- a/src/webcomponents/job/job-view.js
+++ b/src/webcomponents/job/job-view.js
@@ -254,7 +254,14 @@ export default class JobView extends LitElement {
                                     if (job.params) {
                                         return Object.entries(job.params).map(([param, value]) => html`
                                             <div>
-                                                <label>${param}</label>: ${value ? value : "-"}
+                                                <label>${param}</label>: 
+                                                ${value && typeof value === "object" ? html`
+                                                    <ul>
+                                                        ${Object.keys(value).map(key => html`
+                                                            <li><b>${key}</b>: ${value[key] || "-"}</li>
+                                                        `)}
+                                                    </ul>
+                                                ` : (value || "-")}
                                             </div>
                                         `);
                                     } else {


### PR DESCRIPTION
This PR fix displaying the job params in the `job-view` component.