### PR TITLE
TASK-1875 - IVA Sample browser shows a "Type error" when some attributes have  undefined values

### DIFF
--- a/src/webcomponents/sample/sample-grid.js
+++ b/src/webcomponents/sample/sample-grid.js
@@ -159,7 +159,7 @@ export default class SampleGrid extends LitElement {
                                     .then(caseResponse => {
                                         sampleResponse.getResults().forEach(sample => {
                                             for (const clinicalAnalysis of caseResponse.getResults()) {
-                                                if (clinicalAnalysis?.proband?.id === sample.individualId || clinicalAnalysis?.family?.members.find(member => member.id === sample.individualId)) {
+                                                if (clinicalAnalysis?.proband?.id === sample.individualId || clinicalAnalysis?.family?.members?.find(member => member.id === sample.individualId)) {
                                                     if (sample?.attributes?.OPENCGA_CLINICAL_ANALYSIS) {
                                                         sample.attributes.OPENCGA_CLINICAL_ANALYSIS.push(clinicalAnalysis);
                                                     } else {


### PR DESCRIPTION
This PR fixes an error in the sample browser when some samples do not have a `family.members` field.