### PR TITLE
TASK-2082 - Unable to filter by disorders when disorders.name is empty

### DIFF
--- a/src/webcomponents/commons/filters/catalog-distinct-autocomplete.js
+++ b/src/webcomponents/commons/filters/catalog-distinct-autocomplete.js
@@ -32,7 +32,7 @@ export default class CatalogDistinctAutocomplete extends LitElement {
             value: {
                 type: Object
             },
-            distinctField: {
+            distinctFields: {
                 type: String,
             },
             queryField: {
@@ -89,7 +89,7 @@ export default class CatalogDistinctAutocomplete extends LitElement {
                 };
 
                 const page = params?.data?.page || 1;
-                // 'queryField' is the name of the REST parameter to filter documents, normally this will be the same as 'distinctField'.
+                // 'queryField' is the name of the REST parameter to filter documents, normally this will be the same as 'distinctFields'.
                 // But in some cases it can be different. For example, 'disorders' and 'disorders.id'
                 const attr = params?.data?.term ? {[this.queryField]: "~/" + params?.data?.term + "/i"} : null;
                 const filters = {
@@ -101,7 +101,7 @@ export default class CatalogDistinctAutocomplete extends LitElement {
                 };
 
                 // The exact name of the field, see the example above about 'disorders' and 'disorders.id'
-                RESOURCES[this.resource].distinct(this.distinctField, filters)
+                RESOURCES[this.resource].distinct(this.distinctFields, filters)
                     .then(response => {
                         if (params?.data?.term) {
                             const term = params.data.term.toUpperCase();

--- a/src/webcomponents/commons/opencga-browser-filter.js
+++ b/src/webcomponents/commons/opencga-browser-filter.js
@@ -95,7 +95,7 @@ export default class OpencgaBrowserFilter extends LitElement {
         // Select the right distinct field to be displayed
         this.filterToDistinctField = {
             "phenotypes": "phenotypes.name",
-            "disorders": "disorders.name",
+            "disorders": "disorders.id,disorders.name",
             "ethnicity": "ethnicity.id",
             "proband": "proband.id",
             "tool": "tool.id",
@@ -235,7 +235,7 @@ export default class OpencgaBrowserFilter extends LitElement {
                         <catalog-distinct-autocomplete
                             .value="${this.preparedQuery[subsection.id]}"
                             .queryField="${subsection.id}"
-                            .distinctField="${this.filterToDistinctField[subsection.id]}"
+                            .distinctFields="${this.filterToDistinctField[subsection.id]}"
                             .resource="${this.resource}"
                             .opencgaSession="${this.opencgaSession}"
                             .config="${subsection}"

--- a/src/webcomponents/commons/opencga-browser-filter.js
+++ b/src/webcomponents/commons/opencga-browser-filter.js
@@ -94,7 +94,7 @@ export default class OpencgaBrowserFilter extends LitElement {
 
         // Select the right distinct field to be displayed
         this.filterToDistinctField = {
-            "phenotypes": "phenotypes.name",
+            "phenotypes": "phenotypes.id,phenotypes.name",
             "disorders": "disorders.id,disorders.name",
             "ethnicity": "ethnicity.id",
             "proband": "proband.id",

--- a/src/webcomponents/file/file-filter.js
+++ b/src/webcomponents/file/file-filter.js
@@ -187,7 +187,7 @@ export default class OpencgaFileFilter extends LitElement {
                     <catalog-distinct-autocomplete
                         .value="${this.preparedQuery[subsection.id]}"
                         .queryField="${"path"}"
-                        .distinctField="${"path"}"
+                        .distinctFields="${"path"}"
                         .resource="${"FILE"}"
                         .opencgaSession="${this.opencgaSession}"
                         .config="${subsection}"


### PR DESCRIPTION
This PR fixes filtering by disorders when the field `disorders.name` is empty.