### PR TITLE
TASK-2130 - Sample Genotypes filter is not applying Mode of Inheritance

### DIFF
--- a/src/webcomponents/variant/family-genotype-filter.js
+++ b/src/webcomponents/variant/family-genotype-filter.js
@@ -313,7 +313,7 @@ export default class FamilyGenotypeFilter extends LitElement {
         }
 
         // Mode of Inheritance
-        if (this.modeOfInheritanceList.includes(this.mode)) {
+        if (this.modeOfInheritanceList.some(item => item.id === this.mode)) {
             this.onModeOfInheritance(this.mode);
         }
 


### PR DESCRIPTION
This PR fixes selecting a mode of inheritance in the `family-genotype-filter` component.