### PR TITLE
TASK-2182 - Sample Variant Stats fail to create index due to the missing param indexId

### DIFF
--- a/src/webcomponents/variant/analysis/sample-variant-stats-analysis.js
+++ b/src/webcomponents/variant/analysis/sample-variant-stats-analysis.js
@@ -99,6 +99,7 @@ export default class SampleVariantStatsAnalysis extends LitElement {
             individual: this.toolParams.individual?.split(",") || [],
             variantQuery: this.toolParams.variantQuery || {},
             index: this.toolParams.index ?? false,
+            indexId: this.toolParams.indexId || "",
         };
         const params = {
             study: this.opencgaSession.study.fqn,
@@ -188,9 +189,15 @@ export default class SampleVariantStatsAnalysis extends LitElement {
                         title: "Index",
                         field: "index",
                         type: "checkbox",
-                        display: {
-                        },
                     },
+                    {
+                        title: "Index ID",
+                        field: "indexId",
+                        type: "input-text",
+                        display: {
+                            disabled: !this.toolParams.index,
+                        },
+                    }
                 ]
             }
         ];


### PR DESCRIPTION
This PR adds a missing `indexId` field to the `sample-variant-stats-analysis` component.