### PR TITLE
TASK-2100 - Sex filter in Individual browser only accept uppercase MALE and FEMALE and fail to search other capitalizations

### DIFF
--- a/src/webcomponents/commons/opencga-browser-filter.js
+++ b/src/webcomponents/commons/opencga-browser-filter.js
@@ -102,7 +102,9 @@ export default class OpencgaBrowserFilter extends LitElement {
             "genes": "genes.id",
             "categories": "categories.name",
             "source": "source.name",
-            "tags": "tags"
+            "tags": "tags",
+            "sex": "sex.id",
+            "karyotypicSex": "karyotypicSex",
         };
     }
 
@@ -231,6 +233,8 @@ export default class OpencgaBrowserFilter extends LitElement {
                 case "genes":
                 case "tags":
                 case "source":
+                case "sex":
+                case "karyotypicSex":
                     content = html`
                         <catalog-distinct-autocomplete
                             .value="${this.preparedQuery[subsection.id]}"
@@ -243,9 +247,7 @@ export default class OpencgaBrowserFilter extends LitElement {
                         </catalog-distinct-autocomplete>
                     `;
                     break;
-                case "sex":
                 case "type": // cohort, clinical
-                case "karyotypicSex":
                 case "affectationStatus":
                 case "lifeStatus":
                 case "format":

--- a/src/webcomponents/individual/individual-browser.js
+++ b/src/webcomponents/individual/individual-browser.js
@@ -201,15 +201,12 @@ export default class IndividualBrowser extends LitElement {
                             {
                                 id: "sex",
                                 name: "Sex",
-                                allowedValues: ["MALE", "FEMALE", "UNKNOWN", "UNDETERMINED"],
                                 multiple: true,
                                 description: ""
                             },
                             {
                                 id: "karyotypicSex",
                                 name: "Karyotypic Sex",
-                                type: "category",
-                                allowedValues: ["XX", "XY", "XO", "XXY", "XXX", "XXYY", "XXXY", "XXXX", "XYY", "OTHER", "UNKNOWN"],
                                 multiple: true,
                                 description: ""
                             },


### PR DESCRIPTION
This PR fixes the sex and karyotypic filters in individual browser.