### PR TITLE
TASK-2235 - Copy JSON feature doesn't work if users use HTTP URLs

### DIFF
--- a/src/core/utils-new.js
+++ b/src/core/utils-new.js
@@ -896,4 +896,27 @@ export default class UtilsNew {
         return versionNumber2 - versionNumber1;
     }
 
+    // Wrapper around Clipboard API for supporting non secure contexts (HTTP)
+    static copyToClipboard(text) {
+        return Promise.resolve().then(() => {
+            if (window?.navigator?.clipboard?.writeText) {
+                return window.navigator.clipboard.writeText(text);
+            } else {
+                const el = document.createElement("textarea");
+                el.value = text;
+                el.setAttribute("readonly", "");
+                el.style.contain = "strict";
+                el.style.position = "absolute";
+                el.style.left = "-9999px";
+
+                document.body.appendChild(el);
+                el.select();
+                const copied = document.execCommand("copy");
+                document.body.removeChild(el);
+
+                return copied;
+            }
+        });
+    }
+
 }

--- a/src/webcomponents/variant/interpretation/variant-interpreter-grid.js
+++ b/src/webcomponents/variant/interpretation/variant-interpreter-grid.js
@@ -1202,7 +1202,7 @@ export default class VariantInterpreterGrid extends LitElement {
                 });
                 break;
             case "copy-json":
-                navigator.clipboard.writeText(JSON.stringify(row, null, "\t"));
+                UtilsNew.copyToClipboard(JSON.stringify(row, null, "\t"));
                 break;
             case "download":
                 UtilsNew.downloadData([JSON.stringify(row, null, "\t")], row.id + ".json");
@@ -1232,7 +1232,7 @@ export default class VariantInterpreterGrid extends LitElement {
                     });
                     const showArrayIndexes = VariantGridFormatter._consequenceTypeDetailFormatterFilter(newEvidences, this._config).indexes;
 
-                    navigator.clipboard.writeText(copy.execute(row, showArrayIndexes));
+                    UtilsNew.copyToClipboard(copy.execute(row, showArrayIndexes));
                 }
                 break;
         }


### PR DESCRIPTION
This PR adds a new wrapper around Clipboard API for supporting non-secure contexts (HTTP).