### PR TITLE
TASK-2266 - When an interpretation is locked a wrong Lock Image is displayed as if the case where locked

### DIFF
--- a/src/webcomponents/variant/interpretation/variant-interpreter.js
+++ b/src/webcomponents/variant/interpretation/variant-interpreter.js
@@ -337,7 +337,7 @@ class VariantInterpreter extends LitElement {
                             ${this._config.title}
                             <span class="inverse">
                                 Case ${this.clinicalAnalysis?.id}
-                                ${this.clinicalAnalysis.interpretation.locked ? "<span class=\"fa fa-lock\"></span>" : ""}
+                                ${this.clinicalAnalysis?.locked ? "<span class=\"fa fa-lock icon-padding\"></span>" : ""}
                             </span>
                         `}"
                         .rhs="${html`


### PR DESCRIPTION
This PR setting the right lock icon when a locked case is displayed