### PR TITLE
TASK-2444 - The Index column is displayed empty in the table of the File Browser

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "bootstrap-3-typeahead": "^4.0.2",
     "bootstrap-colorpicker": "2.3.6",
     "bootstrap-select": "^1.13.18",
-    "bootstrap-table": "^1.18.3",
+    "bootstrap-table": "1.21.2",
     "bootstrap-treeview": "git@github.com:jonmiles/bootstrap-treeview.git#develop",
     "bootstrap-validator": "~0.11.9",
     "clipboard": "^2.0.6",

--- a/src/sites/iva/conf/opencga-file-browser.settings.js
+++ b/src/sites/iva/conf/opencga-file-browser.settings.js
@@ -7,7 +7,6 @@ const OPENCGA_FILE_BROWSER_SETTINGS = {
         sections: [
             {
                 filters: ["name", "sampleIds", /* "path",*/ "directory", "jobId", "format", "bioformat", "internalVariantIndexStatus", "date", "annotations"]
-                // filters: ["name", "sampleIds", /* "path",*/ "directory", "jobId", "format", "bioformat", "internal.index.status.name", "date", "annotations"]
             }
         ],
         // merge criterium: full outer join-like. it adds objects presents in internal array only and in external array only. In case of same id, the external value overwrite the internal.

--- a/src/sites/iva/conf/opencga-file-browser.settings.js
+++ b/src/sites/iva/conf/opencga-file-browser.settings.js
@@ -6,7 +6,8 @@ const OPENCGA_FILE_BROWSER_SETTINGS = {
         // merge criterium: internal sections and filters are used to hydrates the external filters list for each section (which is a list of string). Sections and filter order is respected.
         sections: [
             {
-                filters: ["name", "sampleIds", /* "path",*/ "directory", "jobId", "format", "bioformat", "internal.index.status.name", "date", "annotations"]
+                filters: ["name", "sampleIds", /* "path",*/ "directory", "jobId", "format", "bioformat", "internal.variant.index.status.id", "date", "annotations"]
+                // filters: ["name", "sampleIds", /* "path",*/ "directory", "jobId", "format", "bioformat", "internal.index.status.name", "date", "annotations"]
             }
         ],
         // merge criterium: full outer join-like. it adds objects presents in internal array only and in external array only. In case of same id, the external value overwrite the internal.

--- a/src/sites/iva/conf/opencga-file-browser.settings.js
+++ b/src/sites/iva/conf/opencga-file-browser.settings.js
@@ -6,7 +6,7 @@ const OPENCGA_FILE_BROWSER_SETTINGS = {
         // merge criterium: internal sections and filters are used to hydrates the external filters list for each section (which is a list of string). Sections and filter order is respected.
         sections: [
             {
-                filters: ["name", "sampleIds", /* "path",*/ "directory", "jobId", "format", "bioformat", "internal.variant.index.status.id", "date", "annotations"]
+                filters: ["name", "sampleIds", /* "path",*/ "directory", "jobId", "format", "bioformat", "internalVariantIndexStatus", "date", "annotations"]
                 // filters: ["name", "sampleIds", /* "path",*/ "directory", "jobId", "format", "bioformat", "internal.index.status.name", "date", "annotations"]
             }
         ],

--- a/src/webcomponents/commons/opencga-browser-filter.js
+++ b/src/webcomponents/commons/opencga-browser-filter.js
@@ -253,8 +253,7 @@ export default class OpencgaBrowserFilter extends LitElement {
                 case "lifeStatus":
                 case "format":
                 case "bioformat":
-                case "internal.variant.index.status.id": // DEPRECATED: "internal.index.status.name"
-                case "internalVariantIndexStatus": // "internal.index.status.name"
+                case "internalVariantIndexStatus":
                 case "internalStatus":
                 case "visited":
                 case "job_priority":

--- a/src/webcomponents/commons/opencga-browser-filter.js
+++ b/src/webcomponents/commons/opencga-browser-filter.js
@@ -188,7 +188,7 @@ export default class OpencgaBrowserFilter extends LitElement {
         if (subsection.render) {
             content = subsection.render(this.onFilterChange, this.preparedQuery, this.opencgaSession);
         } else {
-            const id = subsection.id === "priority"? `${this.resource.toLowerCase()}_${subsection.id}`: subsection.id;
+            const id = subsection.id === "priority" ? `${this.resource.toLowerCase()}_${subsection.id}`: subsection.id;
             switch (id) {
                 case "id":
                 case "name":
@@ -253,7 +253,8 @@ export default class OpencgaBrowserFilter extends LitElement {
                 case "lifeStatus":
                 case "format":
                 case "bioformat":
-                case "internal.variant.index.status.id": // "internal.index.status.name"
+                case "internal.variant.index.status.id": // DEPRECATED: "internal.index.status.name"
+                case "internalVariantIndexStatus": // "internal.index.status.name"
                 case "internalStatus":
                 case "visited":
                 case "job_priority":

--- a/src/webcomponents/commons/opencga-browser-filter.js
+++ b/src/webcomponents/commons/opencga-browser-filter.js
@@ -253,7 +253,7 @@ export default class OpencgaBrowserFilter extends LitElement {
                 case "lifeStatus":
                 case "format":
                 case "bioformat":
-                case "internal.index.status.name":
+                case "internal.variant.index.status.id": // "internal.index.status.name"
                 case "internalStatus":
                 case "visited":
                 case "job_priority":

--- a/src/webcomponents/file/file-browser.js
+++ b/src/webcomponents/file/file-browser.js
@@ -228,10 +228,16 @@ export default class FileBrowser extends LitElement {
                                 description: ""
                             },
                             {
-                                id: "internal.index.status.name",
+                                // id: "internal.index.status.name",
+                                id: "internal.variant.index.status.id",
                                 name: "Index Status",
                                 multiple: true,
-                                allowedValues: ["READY", "DELETED", "TRASHED", "STAGE", "MISSING", "PENDING_DELETE", "DELETING", "REMOVED", "NONE"],
+                                // CAUTION NOTE 2023 Vero: This allowed values correspond to the file status, not to the index status
+                                // "READY", "DELETED", "TRASHED", "STAGE", "MISSING", "PENDING_DELETE", "DELETING", "REMOVED", "NONE",
+                                // NOTE 2023 Vero: The current variant.index.status vocabulary is:
+                                // "READY", "DELETED", "NONE", "TRANSFORMED", "TRANSFORMING", "LOADING", "INDEXING"
+                                // But the DELETED status is moved in opencga to NONE.
+                                allowedValues: ["READY", "NONE", "TRANSFORMED", "TRANSFORMING", "LOADING", "INDEXING"],
                                 type: "category"
                             },
                             {

--- a/src/webcomponents/file/file-browser.js
+++ b/src/webcomponents/file/file-browser.js
@@ -228,8 +228,7 @@ export default class FileBrowser extends LitElement {
                                 description: ""
                             },
                             {
-                                // id: "internal.index.status.name",
-                                id: "internal.variant.index.status.id",
+                                id: "internalVariantIndexStatus",
                                 name: "Index Status",
                                 multiple: true,
                                 // CAUTION NOTE 2023 Vero: This allowed values correspond to the file status, not to the index status

--- a/src/webcomponents/file/file-browser.js
+++ b/src/webcomponents/file/file-browser.js
@@ -229,13 +229,11 @@ export default class FileBrowser extends LitElement {
                             },
                             {
                                 id: "internalVariantIndexStatus",
-                                name: "Index Status",
+                                name: "Variant Index Status",
                                 multiple: true,
-                                // CAUTION NOTE 2023 Vero: This allowed values correspond to the file status, not to the index status
-                                // "READY", "DELETED", "TRASHED", "STAGE", "MISSING", "PENDING_DELETE", "DELETING", "REMOVED", "NONE",
-                                // NOTE 2023 Vero: The current variant.index.status vocabulary is:
+                                // NOTE 20230310 Vero: The current internalVariantIndexStatus (internal.variant.index.status) vocabulary is:
                                 // "READY", "DELETED", "NONE", "TRANSFORMED", "TRANSFORMING", "LOADING", "INDEXING"
-                                // But the DELETED status is moved in opencga to NONE.
+                                // But the DELETED status gets mapped in opencga to NONE (Jacobo)
                                 allowedValues: ["READY", "NONE", "TRANSFORMED", "TRANSFORMING", "LOADING", "INDEXING"],
                                 type: "category"
                             },

--- a/src/webcomponents/file/file-filter.js
+++ b/src/webcomponents/file/file-filter.js
@@ -207,7 +207,6 @@ export default class OpencgaFileFilter extends LitElement {
             case "format":
             case "bioformat":
             case "internal.variant.index.status.id":
-                // case "internal.index.status.name":
                 content = html`
                     <select-field-filter
                         multiple

--- a/src/webcomponents/file/file-filter.js
+++ b/src/webcomponents/file/file-filter.js
@@ -206,7 +206,8 @@ export default class OpencgaFileFilter extends LitElement {
                 break;
             case "format":
             case "bioformat":
-            case "internal.index.status.name":
+            case "internal.variant.index.status.id":
+                // case "internal.index.status.name":
                 content = html`
                     <select-field-filter
                         multiple

--- a/src/webcomponents/file/file-grid.js
+++ b/src/webcomponents/file/file-grid.js
@@ -284,9 +284,19 @@ export default class OpencgaFileGrid extends LitElement {
             // },
             {
                 id: "index",
-                title: "Index",
+                title: "Variant Index Status",
                 // field: "internal.index.status.name",
-                field: "internal.variant.index.status.id"
+                field: "internal.variant.index.status.id",
+                // formatter: (value, row) => {
+                //     if (row.format === "VCF") {
+                //         return `
+                //             <div>${row.internal.variant.index?.status?.id}</div>
+                //             <div>${row.internal.variant.annotationIndex?.status?.id}</div>
+                //         `;
+                //     } else {
+                //         return `<div>NA</div>`;
+                //     }
+                // }
             },
             {
                 id: "creationDate",

--- a/src/webcomponents/file/file-grid.js
+++ b/src/webcomponents/file/file-grid.js
@@ -285,7 +285,8 @@ export default class OpencgaFileGrid extends LitElement {
             {
                 id: "index",
                 title: "Index",
-                field: "internal.index.status.name"
+                // field: "internal.index.status.name",
+                field: "internal.variant.index.status.id"
             },
             {
                 id: "creationDate",

--- a/src/webcomponents/file/file-grid.js
+++ b/src/webcomponents/file/file-grid.js
@@ -285,8 +285,9 @@ export default class OpencgaFileGrid extends LitElement {
             {
                 id: "index",
                 title: "Variant Index Status",
-                // field: "internal.index.status.name",
                 field: "internal.variant.index.status.id",
+                // NOTE 20230310 Vero: Formatter for displaying in the future information
+                // about annotation and secondary index in the column
                 // formatter: (value, row) => {
                 //     if (row.format === "VCF") {
                 //         return `

--- a/src/webcomponents/file/file-view.js
+++ b/src/webcomponents/file/file-view.js
@@ -244,11 +244,15 @@ export default class FileView extends LitElement {
                             },
                         },
                         {
-                            title: "Index Status",
-                            field: "internal.index.status",
+                            // title: "Index Status",
+                            title: "Variant Index Status",
+                            // field: "internal.index.status",
+                            field: "internal.variant.index.status",
                             type: "custom",
                             display: {
-                                render: field => field?.name ? html`${field.name} (${UtilsNew.dateFormatter(field.date)})` : "-",
+                                render: field => {
+                                    return field?.id ? html`${field.id} (${UtilsNew.dateFormatter(field.date)})` : "-";
+                                }
                             },
                         },
                     ],

--- a/src/webcomponents/file/file-view.js
+++ b/src/webcomponents/file/file-view.js
@@ -246,7 +246,6 @@ export default class FileView extends LitElement {
                         {
                             // title: "Index Status",
                             title: "Variant Index Status",
-                            // field: "internal.index.status",
                             field: "internal.variant.index.status",
                             type: "custom",
                             display: {


### PR DESCRIPTION
This PR fixes the query and visualisation of the Variant Index in File browser grid and view.