### PR TITLE
TASK-1562 - Pedigree graph with a three-generation family fails to render properly in Family browser detailed tab

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "bootstrap-3-typeahead": "^4.0.2",
     "bootstrap-colorpicker": "2.3.6",
     "bootstrap-select": "^1.13.18",
-    "bootstrap-table": "^1.18.3",
+    "bootstrap-table": "1.21.2",
     "bootstrap-treeview": "git@github.com:jonmiles/bootstrap-treeview.git#develop",
     "bootstrap-validator": "~0.11.9",
     "clipboard": "^2.0.6",

--- a/src/webcomponents/clinical/clinical-analysis-view.js
+++ b/src/webcomponents/clinical/clinical-analysis-view.js
@@ -19,7 +19,7 @@ import UtilsNew from "../../core/utils-new.js";
 import LitUtils from "../commons/utils/lit-utils";
 import CatalogGridFormatter from "../commons/catalog-grid-formatter.js";
 import "../commons/forms/data-form.js";
-import "../commons/view/pedigree-view.js";
+import "../commons/image-viewer.js";
 
 
 export default class ClinicalAnalysisView extends LitElement {
@@ -471,20 +471,14 @@ export default class ClinicalAnalysisView extends LitElement {
                                 errorMessage: "No family selected",
                             },
                         },
-                        // {
-                        //     title: "Members JSON",
-                        //     field: "family.members",
-                        //     type: "json"
-                        // },
                         {
                             title: "Pedigree",
                             type: "custom",
                             display: {
-                                // TODO at the moment pedigree doesn't work with families with over 2 generations
-                                visible: !this._config?.hiddenFields?.includes("pedigree"),
-                                layout: "vertical",
                                 render: clinicalAnalysis => html`
-                                    <pedigree-view .family="${clinicalAnalysis.family}"></pedigree-view>
+                                    <image-viewer
+                                        .data="${clinicalAnalysis?.family?.pedigreeGraph?.base64}">
+                                    </image-viewer>
                                 `,
                             },
                         }

--- a/src/webcomponents/clinical/clinical-analysis-view.js
+++ b/src/webcomponents/clinical/clinical-analysis-view.js
@@ -369,13 +369,20 @@ export default class ClinicalAnalysisView extends LitElement {
                             type: "custom",
                             display: {
                                 render: phenotypes => {
-                                    if (phenotypes) {
-                                        return [...phenotypes].sort((a, b) => a.status === "OBSERVED" ? -1 : 1).map(phenotype => html`
-                                            ${phenotype.source && phenotype.source.toUpperCase() === "HPO" ?
-                                                html`<li>${phenotype.name} (<a target="_blank" href="https://hpo.jax.org/app/browse/term/${phenotype.id}">${phenotype.id}</a>) - ${phenotype.status}</li>` :
-                                                html`<li>${phenotype.id} - ${phenotype.status}</li>`}`
-                                        );
-                                    }
+                                    return (phenotypes || [])
+                                        .sort(item => item?.status === "OBSERVED" ? -1 : 1)
+                                        .map(phenotype => {
+                                            if (phenotype?.source && phenotype?.source?.toUpperCase() === "HPO") {
+                                                const url = `https://hpo.jax.org/app/browse/term/${phenotype.id}`;
+                                                return html`
+                                                    <li>${phenotype.name} (<a target="_blank" href="${url}">${phenotype.id}</a>) - ${phenotype.status}</li>
+                                                `;
+                                            } else {
+                                                return html`
+                                                    <li>${phenotype.id} - ${phenotype.status}</li>
+                                                `;
+                                            }
+                                        });
                                 },
                                 defaultValue: "N/A",
                             },

--- a/src/webcomponents/family/family-view.js
+++ b/src/webcomponents/family/family-view.js
@@ -19,7 +19,7 @@ import UtilsNew from "../../core/utils-new.js";
 import Types from "../commons/types.js";
 import CatalogGridFormatter from "../commons/catalog-grid-formatter.js";
 import "../commons/forms/data-form.js";
-import "../commons/view/pedigree-view.js";
+import "../commons/image-viewer.js";
 import "../loading-spinner.js";
 import LitUtils from "../commons/utils/lit-utils";
 
@@ -353,10 +353,10 @@ export default class FamilyView extends LitElement {
                             title: "Pedigree",
                             type: "custom",
                             display: {
-                                defaultLayout: "vertical",
-                                visible: !this._config?.hiddenFields?.includes("pedigree"),
                                 render: () => html`
-                                    <pedigree-view .family="${this.family}"></pedigree-view>
+                                    <image-viewer
+                                        .data="${this.family?.pedigreeGraph?.base64}">
+                                    </image-viewer>
                                 `,
                             }
                         }


### PR DESCRIPTION
This PR updates the `family-view` and the `clinical-analysis-view` for using the new pedigree image returned in the family object.