### PR TITLE
TASK-4016 - Variant Browser - gnomAD exomes information out of window margin

### DIFF
--- a/src/webcomponents/variant/variant-grid-formatter.js
+++ b/src/webcomponents/variant/variant-grid-formatter.js
@@ -927,7 +927,7 @@ export default class VariantGridFormatter {
         if (populationFrequenciesConfig?.displayMode === "FREQUENCY_BOX") {
             const tableSize = populations.length * 15;
             htmlPopFreqTable = `
-                <a tooltip-title="Population Frequencies" tooltip-text="${tooltip}">
+                <a tooltip-title="Population Frequencies" tooltip-text="${tooltip}" tooltip-position-my="top right">
                 <table style="width:${tableSize}px" class="populationFrequenciesTable">
                     <tr>
             `;


### PR DESCRIPTION
This PR fixes the position of the tooltip displayed in the Population Frequencies column of Variant Browser.