### PR TITLE
TASK-4027 - Cohort Stats information displayed in the Sample Variant Browser table doesn't match with the information shown in the Details Tab

### DIFF
--- a/src/webcomponents/variant/interpretation/variant-interpreter-grid-formatter.js
+++ b/src/webcomponents/variant/interpretation/variant-interpreter-grid-formatter.js
@@ -56,8 +56,7 @@ export default class VariantInterpreterGridFormatter {
                 const arr = study.studyId.split(":");
                 const s = arr[arr.length - 1] + ":ALL";
                 cohorts.push(s);
-                // cohortMap.set(s, study.stats.length ? Number(study.stats[0].altAlleleFreq).toPrecision(4) : "-");
-                cohortMap.set(s, study.stats);
+                cohortMap.set(s, (study.stats || []).find(stats => stats?.cohortId === "ALL"));
             });
             return VariantGridFormatter.renderPopulationFrequencies(
                 cohorts,


### PR DESCRIPTION
This PR fixes the cohort stats tooltip displayed in the variant interpreter grid.