### PR TITLE
TASK-4017 - Modifications are not saved when attempting to change the analyst of an already assigned interpretation

### DIFF
--- a/src/webcomponents/commons/opencga-update.js
+++ b/src/webcomponents/commons/opencga-update.js
@@ -304,6 +304,12 @@ export default class OpencgaUpdate extends LitElement {
                                         tags: UtilsNew.commaSeparatedArray(comment.tags),
                                     }));
                             }
+                            if (params.analyst?.id) {
+                                // eslint-disable-next-line no-param-reassign
+                                params.analyst = {
+                                    id: params.analyst.id,
+                                };
+                            }
                         },
                     ];
                     break;


### PR DESCRIPTION
This PR adds a new update customization in `opencga-update` for the `analyst.id` field of the interpretation.