### PR TITLE
TASK-729 - Display genomic location default filter

### DIFF
--- a/src/webcomponents/sample/sample-cancer-variant-stats-browser.js
+++ b/src/webcomponents/sample/sample-cancer-variant-stats-browser.js
@@ -71,7 +71,9 @@ export default class SampleCancerVariantStatsBrowser extends LitElement {
             density: "MEDIUM",
             format: "SVG"
         };
-
+        this.query = {
+            region: "1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,X,Y",
+        };
         this.queries = {};
         this.circosPlot = null;
         this.signature = {};

--- a/src/webcomponents/sample/sample-cancer-variant-stats-plots.js
+++ b/src/webcomponents/sample/sample-cancer-variant-stats-plots.js
@@ -112,11 +112,6 @@ export default class SampleCancerVariantStatsPlots extends LitElement {
             // ...this.queries?.["SNV"]
         };
 
-        // Add default region filter including only canonical chromosomes
-        if (!params.region) {
-            params.region = "1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,X,Y";
-        }
-
         // Query SNV
         this.opencgaSession.opencgaClient.variants().queryMutationalSignature({
             ...params,
@@ -167,11 +162,6 @@ export default class SampleCancerVariantStatsPlots extends LitElement {
             ...this.query,
             ...this.queries?.["INDEL"]
         };
-
-        // Add default region filter including only canonical chromosomes
-        if (!params.region) {
-            params.region = "1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,X,Y";
-        }
 
         this.opencgaSession.opencgaClient.variants().aggregationStatsSample(params)
             .then(response => {


### PR DESCRIPTION
This PR fixes the default location filter in the `sample-cancer-variant-stats-browser` component.