### PR TITLE
TASK-4501 - Create family case modal still uses the old pedigree module and is unable to properly plot families larger than trios

### DIFF
--- a/src/webcomponents/clinical/clinical-analysis-create.js
+++ b/src/webcomponents/clinical/clinical-analysis-create.js
@@ -22,6 +22,7 @@ import UtilsNew from "../../core/utils-new.js";
 import "../commons/forms/data-form.js";
 import "../commons/filters/disease-panel-filter.js";
 import "../commons/filters/catalog-search-autocomplete.js";
+import "../commons/image-viewer.js";
 import "./filters/clinical-priority-filter.js";
 import "./filters/clinical-flag-filter.js";
 
@@ -651,11 +652,15 @@ export default class ClinicalAnalysisCreate extends LitElement {
                             title: "Pedigree",
                             type: "custom",
                             display: {
-                                // defaultLayout: "vertical",
                                 render: data => {
-                                    if (data.family) {
-                                        return html`<pedigree-view .family="${data.family}"></pedigree-view>`;
+                                    if (data?.family?.pedigreeGraph?.base64) {
+                                        return html`
+                                            <image-viewer
+                                                .data="${data.family?.pedigreeGraph?.base64}">
+                                            </image-viewer>
+                                        `;
                                     }
+                                    return "-";
                                 },
                                 errorMessage: "No family selected",
                             }


### PR DESCRIPTION
This PR fixes the pedigree displayed in the `clinical-analysis-create`.