### PR TITLE
TASK-5494 - File, fileData and sample filters are not kept when applying a saved filter

### DIFF
--- a/src/webcomponents/variant/interpretation/variant-interpreter-browser-cancer.js
+++ b/src/webcomponents/variant/interpretation/variant-interpreter-browser-cancer.js
@@ -275,10 +275,14 @@ class VariantInterpreterBrowserCancer extends LitElement {
     }
 
     getDefaultConfig() {
-        // Add case panels to query object
-        // TODO should we also check main interpretation panels?
-        const lockedFields = [{id: "sample"}];
+        const lockedFields = [
+            {id: "sample"},
+            {id: "sampleData"},
+            {id: "file"},
+            {id: "fileData"},
+        ];
 
+        // Add panels to locked fields
         if (this.clinicalAnalysis?.panels?.length > 0 && this.clinicalAnalysis.panelLock) {
             lockedFields.push({id: "panel"});
             lockedFields.push({id: "panelIntersection"});

--- a/src/webcomponents/variant/interpretation/variant-interpreter-browser-cnv.js
+++ b/src/webcomponents/variant/interpretation/variant-interpreter-browser-cnv.js
@@ -237,12 +237,15 @@ class VariantInterpreterBrowserCNV extends LitElement {
     }
 
     getDefaultConfig() {
-        // Add case panels to query object
         const lockedFields = [
             {id: "sample"},
+            {id: "sampleData"},
+            {id: "file"},
+            {id: "fileData"},
             {id: "type"},
         ];
 
+        // Add panels to locked fields
         if (this.clinicalAnalysis?.panels?.length > 0 && this.clinicalAnalysis.panelLock) {
             lockedFields.push({id: "panel"});
             lockedFields.push({id: "panelIntersection"});

--- a/src/webcomponents/variant/interpretation/variant-interpreter-browser-rd.js
+++ b/src/webcomponents/variant/interpretation/variant-interpreter-browser-rd.js
@@ -293,7 +293,12 @@ class VariantInterpreterBrowserRd extends LitElement {
     getDefaultConfig() {
         // Add case panels to query object
         // TODO should we also check main interpretation panels?
-        const lockedFields = [{id: "sample"}];
+        const lockedFields = [
+            {id: "sample"},
+            {id: "sampleData"},
+            {id: "file"},
+            {id: "fileData"},
+        ];
 
         if (this.clinicalAnalysis?.panels?.length > 0 && this.clinicalAnalysis.panelLock) {
             lockedFields.push({id: "panel"});

--- a/src/webcomponents/variant/interpretation/variant-interpreter-browser-rd.js
+++ b/src/webcomponents/variant/interpretation/variant-interpreter-browser-rd.js
@@ -291,8 +291,6 @@ class VariantInterpreterBrowserRd extends LitElement {
     }
 
     getDefaultConfig() {
-        // Add case panels to query object
-        // TODO should we also check main interpretation panels?
         const lockedFields = [
             {id: "sample"},
             {id: "sampleData"},
@@ -300,6 +298,7 @@ class VariantInterpreterBrowserRd extends LitElement {
             {id: "fileData"},
         ];
 
+        // Add panels to locked fields
         if (this.clinicalAnalysis?.panels?.length > 0 && this.clinicalAnalysis.panelLock) {
             lockedFields.push({id: "panel"});
             lockedFields.push({id: "panelIntersection"});

--- a/src/webcomponents/variant/interpretation/variant-interpreter-browser-rearrangement.js
+++ b/src/webcomponents/variant/interpretation/variant-interpreter-browser-rearrangement.js
@@ -266,6 +266,13 @@ class VariantInterpreterBrowserRearrangement extends LitElement {
     }
 
     getDefaultConfig() {
+        const lockedFields = [
+            {id: "sample"},
+            {id: "sampleData"},
+            {id: "file"},
+            {id: "fileData"},
+        ];
+
         // Prepare dynamic Variant Caller INFO filters
         const callers = ["Caveman", "strelka", "Pindel", "ASCAT", "Canvas", "BRASS", "Manta", "TNhaplotyper2", "Pisces", "CRAFT"];
         const callerFilters = callers.map(caller => {
@@ -338,7 +345,7 @@ class VariantInterpreterBrowserRearrangement extends LitElement {
                         {id: "fileData", separator: ","},
                     ],
                     hiddenFields: [],
-                    lockedFields: [{id: "sample"}]
+                    lockedFields: lockedFields,
                 },
                 callers: [],
                 sections: [ // sections and subsections, structure and order is respected


### PR DESCRIPTION
This PR locks file, fileData, and sampleData field in Sample Variant Browsers.