### PR TITLE
TASK-5797 - Variant Caller Sample Filter in SVB do not display dropdowns to select comparator and value

### DIFF
--- a/src/webcomponents/commons/filters/variant-file-format-filter.js
+++ b/src/webcomponents/commons/filters/variant-file-format-filter.js
@@ -108,7 +108,7 @@ export default class VariantFileFormatFilter extends LitElement {
     render() {
         return html`
             <data-form
-                .data=${this._sampleData}
+                .data="${this._sampleData}"
                 .config="${this._config}"
                 @fieldChange="${this.filterChange}">
             </data-form>

--- a/src/webcomponents/commons/filters/variant-file-format-filter.js
+++ b/src/webcomponents/commons/filters/variant-file-format-filter.js
@@ -124,7 +124,7 @@ export default class VariantFileFormatFilter extends LitElement {
                 collapsable: true,
                 titleVisible: false,
                 titleWidth: 2,
-                defaultValue: "-",
+                defaultValue: "",
                 defaultLayout: "vertical"
             },
             sections: [
@@ -141,9 +141,9 @@ export default class VariantFileFormatFilter extends LitElement {
                             type: "input-number",
                             comparators: this.depthIndex?.type === "RANGE_LT" ? "<,>=" : "<=,>",
                             allowedValues: this.depthIndex?.thresholds,
-                            defaultValue: "",
                             display: {
-                                visible: () => this.depthIndex?.thresholds?.length > 0
+                                defaultValue: "",
+                                visible: () => this.depthIndex?.thresholds?.length > 0,
                             }
                         },
                         {
@@ -152,9 +152,9 @@ export default class VariantFileFormatFilter extends LitElement {
                             type: "input-number",
                             comparators: this.afIndex?.type === "RANGE_LT" ? "<,>=" : "<=,>",
                             allowedValues: this.afIndex?.thresholds,
-                            defaultValue: "",
                             display: {
-                                visible: () => this.afIndex?.thresholds?.length > 0
+                                defaultValue: "",
+                                visible: () => this.afIndex?.thresholds?.length > 0,
                             }
                         },
                         {
@@ -163,9 +163,9 @@ export default class VariantFileFormatFilter extends LitElement {
                             type: "input-number",
                             comparators: this.extVafIndex?.type === "RANGE_LT" ? "<,>=" : "<=,>",
                             allowedValues: this.extVafIndex?.thresholds,
-                            defaultValue: "",
                             display: {
-                                visible: () => this.extVafIndex?.thresholds?.length > 0
+                                defaultValue: "",
+                                visible: () => this.extVafIndex?.thresholds?.length > 0,
                             }
                         }
                     ]

--- a/src/webcomponents/commons/filters/variant-file-info-filter.js
+++ b/src/webcomponents/commons/filters/variant-file-info-filter.js
@@ -427,7 +427,7 @@ export default class VariantFileInfoFilter extends LitElement {
     render() {
         return html`
             <data-form
-                .data=${this.fileDataQuery}
+                .data="${this.fileDataQuery}"
                 .config="${this._config}"
                 @fieldChange="${this.filterChange}">
             </data-form>

--- a/src/webcomponents/commons/filters/variant-file-info-filter.js
+++ b/src/webcomponents/commons/filters/variant-file-info-filter.js
@@ -469,7 +469,9 @@ export default class VariantFileInfoFilter extends LitElement {
                         allowedValues: field.allowedValues,
                         multiple: field.multiple ?? false,
                         maxOptions: field.maxOptions ?? 1,
-                        defaultValue: "",
+                        display: {
+                            defaultValue: "",
+                        },
                     }))
                 ],
             };
@@ -483,7 +485,7 @@ export default class VariantFileInfoFilter extends LitElement {
                 collapsable: true,
                 titleVisible: false,
                 titleWidth: 2,
-                defaultValue: "-",
+                defaultValue: "",
                 defaultLayout: "vertical"
             },
             sections: _sections,


### PR DESCRIPTION
This PR fixes `variant-file-format-filter` and `variant-file-info-filter`.