### PR TITLE
TASK-5946 - Columns section of Variant Browser settings displays escaped HTML content

### DIFF
--- a/src/webcomponents/variant/interpretation/variant-interpreter-grid-config.js
+++ b/src/webcomponents/variant/interpretation/variant-interpreter-grid-config.js
@@ -253,7 +253,7 @@ export default class VariantInterpreterGridConfig extends LitElement {
                         },
                         {
                             type: "text",
-                            text: "Select the <span style='font-weight: bold'>columns</span> to be displayed",
+                            text: "Select the columns to be displayed",
                             display: {
                                 containerStyle: "margin: 20px 5px 5px 0px",
                             }


### PR DESCRIPTION
This PR removes the HTML tags from the text element displayed as a help block of columns dropdown in Variant Browsers.