### PR TITLE
TASK-6014 - Sample Genotypes columns are hidden in SVB in some circunstancies

### DIFF
--- a/src/webcomponents/variant/interpretation/variant-interpreter-grid.js
+++ b/src/webcomponents/variant/interpretation/variant-interpreter-grid.js
@@ -1082,6 +1082,7 @@ export default class VariantInterpreterGrid extends LitElement {
                         formatter: VariantInterpreterGridFormatter.sampleGenotypeFormatter,
                         align: "center",
                         nucleotideGenotype: true,
+                        excludeFromSettings: true,
                         visible: this.gridCommons.isColumnVisible(samples[i].id, "sampleGenotypes"),
                     });
                 }
@@ -1131,6 +1132,7 @@ export default class VariantInterpreterGrid extends LitElement {
                         formatter: VariantInterpreterGridFormatter.sampleGenotypeFormatter,
                         align: "center",
                         nucleotideGenotype: true,
+                        excludeFromSettings: true,
                         visible: this.gridCommons.isColumnVisible(samples[i].id, "sampleGenotypes"),
                     });
                 }

--- a/src/webcomponents/variant/interpretation/variant-interpreter-grid.js
+++ b/src/webcomponents/variant/interpretation/variant-interpreter-grid.js
@@ -1084,7 +1084,8 @@ export default class VariantInterpreterGrid extends LitElement {
                         align: "center",
                         nucleotideGenotype: true,
                         excludeFromSettings: true,
-                        visible: this.gridCommons.isColumnVisible(samples[i].id, "sampleGenotypes"),
+                        // visible: this.gridCommons.isColumnVisible(samples[i].id, "sampleGenotypes"),
+                        visible: !this._config.hideSampleGenotypes,
                     });
                 }
             }
@@ -1134,7 +1135,8 @@ export default class VariantInterpreterGrid extends LitElement {
                         align: "center",
                         nucleotideGenotype: true,
                         excludeFromSettings: true,
-                        visible: this.gridCommons.isColumnVisible(samples[i].id, "sampleGenotypes"),
+                        // visible: this.gridCommons.isColumnVisible(samples[i].id, "sampleGenotypes"),
+                        visible: !this._config.hideSampleGenotypes,
                     });
                 }
             }
@@ -1552,6 +1554,7 @@ export default class VariantInterpreterGrid extends LitElement {
             hidePopulationFrequencies: false,
             hideClinicalInfo: false,
             hideDeleteriousness: false,
+            hideSampleGenotypes: false,
 
             quality: {
                 qual: 30,

--- a/src/webcomponents/variant/interpretation/variant-interpreter-grid.js
+++ b/src/webcomponents/variant/interpretation/variant-interpreter-grid.js
@@ -563,7 +563,8 @@ export default class VariantInterpreterGrid extends LitElement {
                                     formatter: this.vcfDataFormatter,
                                     halign: this.displayConfigDefault.header.horizontalAlign,
                                     excludeFromSettings: true,
-                                    visible: this.gridCommons.isColumnVisible(columnId, "VCF_Data"),
+                                    // visible: this.gridCommons.isColumnVisible(columnId, "VCF_Data"),
+                                    visible: !this._config.hideVcfFileData,
                                 });
                             }
                         }
@@ -1555,6 +1556,7 @@ export default class VariantInterpreterGrid extends LitElement {
             hideClinicalInfo: false,
             hideDeleteriousness: false,
             hideSampleGenotypes: false,
+            hideVcfFileData: false,
 
             quality: {
                 qual: 30,

--- a/src/webcomponents/variant/interpretation/variant-interpreter-grid.js
+++ b/src/webcomponents/variant/interpretation/variant-interpreter-grid.js
@@ -563,7 +563,6 @@ export default class VariantInterpreterGrid extends LitElement {
                                     formatter: this.vcfDataFormatter,
                                     halign: this.displayConfigDefault.header.horizontalAlign,
                                     excludeFromSettings: true,
-                                    // visible: this.gridCommons.isColumnVisible(columnId, "VCF_Data"),
                                     visible: !this._config.hideVcfFileData,
                                 });
                             }
@@ -1085,7 +1084,6 @@ export default class VariantInterpreterGrid extends LitElement {
                         align: "center",
                         nucleotideGenotype: true,
                         excludeFromSettings: true,
-                        // visible: this.gridCommons.isColumnVisible(samples[i].id, "sampleGenotypes"),
                         visible: !this._config.hideSampleGenotypes,
                     });
                 }
@@ -1136,7 +1134,6 @@ export default class VariantInterpreterGrid extends LitElement {
                         align: "center",
                         nucleotideGenotype: true,
                         excludeFromSettings: true,
-                        // visible: this.gridCommons.isColumnVisible(samples[i].id, "sampleGenotypes"),
                         visible: !this._config.hideSampleGenotypes,
                     });
                 }

--- a/src/webcomponents/variant/interpretation/variant-interpreter-grid.js
+++ b/src/webcomponents/variant/interpretation/variant-interpreter-grid.js
@@ -562,6 +562,7 @@ export default class VariantInterpreterGrid extends LitElement {
                                     colspan: 1,
                                     formatter: this.vcfDataFormatter,
                                     halign: this.displayConfigDefault.header.horizontalAlign,
+                                    excludeFromSettings: true,
                                     visible: this.gridCommons.isColumnVisible(columnId, "VCF_Data"),
                                 });
                             }

--- a/src/webcomponents/variant/interpretation/variant-interpreter-rearrangement-grid.js
+++ b/src/webcomponents/variant/interpretation/variant-interpreter-rearrangement-grid.js
@@ -545,7 +545,6 @@ export default class VariantInterpreterRearrangementGrid extends LitElement {
                                 formatter: (value, row) => this.vcfDataFormatter(value, row[index], field),
                                 halign: "center",
                                 excludeFromSettings: true,
-                                // visible: this.gridCommons.isColumnVisible(id),
                                 visible: !this._config.hideVcfFileData,
                             });
                         });
@@ -1106,10 +1105,9 @@ export default class VariantInterpreterRearrangementGrid extends LitElement {
             showActions: false,
             multiSelection: false,
             nucleotideGenotype: true,
+            hideVcfFileData: false,
 
             alleleStringLengthMax: 50,
-
-            hideVcfFileData: false,
 
             // genotype: {
             //     type: "VCF_CALL"

--- a/src/webcomponents/variant/interpretation/variant-interpreter-rearrangement-grid.js
+++ b/src/webcomponents/variant/interpretation/variant-interpreter-rearrangement-grid.js
@@ -545,7 +545,8 @@ export default class VariantInterpreterRearrangementGrid extends LitElement {
                                 formatter: (value, row) => this.vcfDataFormatter(value, row[index], field),
                                 halign: "center",
                                 excludeFromSettings: true,
-                                visible: this.gridCommons.isColumnVisible(id),
+                                // visible: this.gridCommons.isColumnVisible(id),
+                                visible: !this._config.hideVcfFileData,
                             });
                         });
                     });
@@ -1107,6 +1108,8 @@ export default class VariantInterpreterRearrangementGrid extends LitElement {
             nucleotideGenotype: true,
 
             alleleStringLengthMax: 50,
+
+            hideVcfFileData: false,
 
             // genotype: {
             //     type: "VCF_CALL"

--- a/src/webcomponents/variant/interpretation/variant-interpreter-rearrangement-grid.js
+++ b/src/webcomponents/variant/interpretation/variant-interpreter-rearrangement-grid.js
@@ -544,6 +544,7 @@ export default class VariantInterpreterRearrangementGrid extends LitElement {
                                 colspan: 1,
                                 formatter: (value, row) => this.vcfDataFormatter(value, row[index], field),
                                 halign: "center",
+                                excludeFromSettings: true,
                                 visible: this.gridCommons.isColumnVisible(id),
                             });
                         });


### PR DESCRIPTION
This PR fixes a bug with dynamic columns (Sample Genotypes and VCF File Data) in Sample Variant Browser.