### PR TITLE
TASK-6119 - The URL for clinical case lacks the clinical case ID

### DIFF
--- a/src/sites/iva/iva-app.js
+++ b/src/sites/iva/iva-app.js
@@ -872,7 +872,11 @@ class IvaApp extends LitElement {
 
         // 5. Update location.hash (only if project.id and study.id are defined)
         if (this.opencgaSession?.project?.id && this.opencgaSession?.study?.id) {
-            window.location.hash = `${hashTool || "home"}/${this.opencgaSession.project.id}/${this.opencgaSession.study.id}`;
+            // Josemi NOTE 2024-04-25 Added additional check to prevent removing the query section of the url if the tool is interpreter
+            // as we need it tell IVA which clinical analysis should open if user reloads the browser tab.
+            if (hashTool !== "#interpreter") {
+                window.location.hash = `${hashTool || "home"}/${this.opencgaSession.project.id}/${this.opencgaSession.study.id}`;
+            }
         }
 
         // 6. Parse query fragment in 'featureId'


### PR DESCRIPTION
This PR fixes a bug with the routing of the IVA in the interpreter tool