### PR TITLE
Interpretation create form has the wrong key name for the ID ( "Case id"  instead "Interpretation ID")

### DIFF
--- a/src/webcomponents/clinical/interpretation/clinical-interpretation-create.js
+++ b/src/webcomponents/clinical/interpretation/clinical-interpretation-create.js
@@ -183,7 +183,7 @@ export default class ClinicalInterpretationCreate extends LitElement {
                     title: "General Information",
                     elements: [
                         {
-                            title: "Case Id",
+                            title: "Interpretation Id",
                             field: "id",
                             type: "input-text",
                             defaultValue: this.clinicalAnalysis?.id,

--- a/src/webcomponents/clinical/interpretation/clinical-interpretation-create.js
+++ b/src/webcomponents/clinical/interpretation/clinical-interpretation-create.js
@@ -183,13 +183,13 @@ export default class ClinicalInterpretationCreate extends LitElement {
                     title: "General Information",
                     elements: [
                         {
-                            title: "Interpretation Id",
+                            title: "Interpretation ID",
                             field: "id",
                             type: "input-text",
                             defaultValue: this.clinicalAnalysis?.id,
                             display: {
                                 disabled: true,
-                                helpMessage: "The interpretation Id is generated automatically",
+                                helpMessage: "The interpretation ID is generated automatically",
                             },
                         },
                         {


### PR DESCRIPTION
Fix typo Interpretation create form