### PR TITLE
TASK-6867 - Sample filter in Variant browser is not abled again after deselecting the multiple studies in study filter

### DIFF
--- a/src/webcomponents/commons/forms/select-field-filter.js
+++ b/src/webcomponents/commons/forms/select-field-filter.js
@@ -85,7 +85,6 @@ export default class SelectFieldFilter extends LitElement {
 
     updated(changedProperties) {
         if (changedProperties.has("data") || changedProperties.has("config")) {
-            debugger
             this.loadData();
         }
 

--- a/src/webcomponents/commons/forms/select-field-filter.js
+++ b/src/webcomponents/commons/forms/select-field-filter.js
@@ -85,6 +85,7 @@ export default class SelectFieldFilter extends LitElement {
 
     updated(changedProperties) {
         if (changedProperties.has("data") || changedProperties.has("config")) {
+            debugger
             this.loadData();
         }
 
@@ -309,25 +310,9 @@ export default class SelectFieldFilter extends LitElement {
         };
     }
 
-    filterChange(e) {
-        const disabled = Object.values(e.target.options)
-            .filter(data => data.disabled === true)
-            .map(data => {
-                if (data.selected) {
-                    return data.value;
-                }
-            });
+    filterChange() {
+        const selection = this.select.select2("data").map(el => el.id);
 
-        const selection = Array.isArray(this.select.select2("data")) ?
-            [...this.select.select2("data").map(el => el.id), ...disabled] :
-            this.select.select2("data").map(el => el.id);
-
-        let val = "";
-        if (selection && selection.length) {
-            if (this._config?.multiple) {
-                val = selection.join(",");
-            }
-        }
         LitUtils.dispatchCustomEvent(this, "filterChange", selection.join(","),
         {}, null, {bubbles: false, composed: false});
     }

--- a/src/webcomponents/commons/utils/web-utils.js
+++ b/src/webcomponents/commons/utils/web-utils.js
@@ -49,6 +49,7 @@ export default class WebUtils {
             "JOB": "JOBS",
             "FILE": "FILES",
             "CLINICAL_ANALYSIS": "CLINICAL_ANALYSIS",
+            "VARIANT": "VARIANT",
             "PROJECT": "PROJECTS",
             "STUDY": "STUDIES",
             "USER": "USERS",


### PR DESCRIPTION
This PR solves the problem of enabling back the samples filter after deselecting all studies except the current one.