### PR TITLE
TASK-6930 - Unable to launch variant-stats-index from IVA

### DIFF
--- a/src/webcomponents/study/admin/variant/operations-admin.js
+++ b/src/webcomponents/study/admin/variant/operations-admin.js
@@ -194,7 +194,7 @@ export default class OperationsAdmin extends LitElement {
                                 }
                                 return html`
                                     <variant-annotation-index-operation
-                                        .toolParams="${{project: opencgaSession.project.id}}"
+                                        .toolParams="${{project: opencgaSession.project.fqn}}"
                                         .opencgaSession="${opencgaSession}">
                                     </variant-annotation-index-operation>
                                 `;
@@ -217,7 +217,7 @@ export default class OperationsAdmin extends LitElement {
                                 }
                                 return html`
                                     <variant-secondary-annotation-index-operation
-                                        .toolParams="${{project: opencgaSession.project.id}}"
+                                        .toolParams="${{project: opencgaSession.project.fqn}}"
                                         .opencgaSession="${opencgaSession}">
                                     </variant-secondary-annotation-index-operation>
                                 `;
@@ -265,10 +265,9 @@ export default class OperationsAdmin extends LitElement {
                             visibility: "private",
                             type: "navitem",
                             render: (opencgaSession, study) => {
-                                // CAUTION: no .fqn? in toolParams property?
                                 return html`
                                     <variant-secondary-sample-index-operation
-                                        .toolParams="${{study: study.id}}"
+                                        .toolParams="${{study: study.fqn}}"
                                         .opencgaSession="${opencgaSession}">
                                     </variant-secondary-sample-index-operation>
                                 `;

--- a/src/webcomponents/variant/operation/variant-annotation-index-operation.js
+++ b/src/webcomponents/variant/operation/variant-annotation-index-operation.js
@@ -118,6 +118,7 @@ export default class VariantAnnotationIndexOperation extends LitElement {
     onClear() {
         this.toolParams = {
             ...UtilsNew.objectClone(this.DEFAULT_TOOLPARAMS),
+            project: this.toolParams.project || "",
         };
         this.config = this.getDefaultConfig();
     }

--- a/src/webcomponents/variant/operation/variant-index-operation.js
+++ b/src/webcomponents/variant/operation/variant-index-operation.js
@@ -122,6 +122,7 @@ export default class VariantIndexOperation extends LitElement {
     onClear() {
         this.toolParams = {
             ...UtilsNew.objectClone(this.DEFAULT_TOOLPARAMS),
+            study: this.toolParams.study || "",
         };
         this.config = this.getDefaultConfig();
     }

--- a/src/webcomponents/variant/operation/variant-secondary-annotation-index-operation.js
+++ b/src/webcomponents/variant/operation/variant-secondary-annotation-index-operation.js
@@ -118,6 +118,7 @@ export default class VariantSecondaryAnnotationIndexOperation extends LitElement
     onClear() {
         this.toolParams = {
             ...UtilsNew.objectClone(this.DEFAULT_TOOLPARAMS),
+            project: this.toolParams.project || "",
         };
         this.config = this.getDefaultConfig();
     }

--- a/src/webcomponents/variant/operation/variant-secondary-sample-index-operation.js
+++ b/src/webcomponents/variant/operation/variant-secondary-sample-index-operation.js
@@ -169,7 +169,7 @@ export default class VariantSecondarySampleIndexOperation extends LitElement {
                 title: "Configuration Parameters",
                 elements: [
                     {
-                        title: "Sample",
+                        title: "Sample IDs",
                         type: "custom",
                         required: true,
                         display: {

--- a/src/webcomponents/variant/operation/variant-secondary-sample-index-operation.js
+++ b/src/webcomponents/variant/operation/variant-secondary-sample-index-operation.js
@@ -125,6 +125,7 @@ export default class VariantSecondarySampleIndexOperation extends LitElement {
     onClear() {
         this.toolParams = {
             ...UtilsNew.objectClone(this.DEFAULT_TOOLPARAMS),
+            study: this.toolParams.study || "",
         };
         this.config = this.getDefaultConfig();
     }

--- a/src/webcomponents/variant/operation/variant-stats-index-operation.js
+++ b/src/webcomponents/variant/operation/variant-stats-index-operation.js
@@ -56,7 +56,6 @@ export default class VariantStatsIndexOperation extends LitElement {
             ...UtilsNew.objectClone(this.DEFAULT_TOOLPARAMS),
         };
 
-        this.study = "";
         this.config = this.getDefaultConfig();
     }
 
@@ -84,6 +83,11 @@ export default class VariantStatsIndexOperation extends LitElement {
                 message: "Study is a mandatory parameter, please select one."
             };
         }
+        if (!this.toolParams.cohort) {
+            return {
+                message: "Cohort IDs is a mandatory parameter, please select some cohorts."
+            };
+        }
         return null;
     }
 
@@ -98,6 +102,7 @@ export default class VariantStatsIndexOperation extends LitElement {
 
     onSubmit() {
         const toolParams = {
+            cohort: this.toolParams.cohort?.split(",") || [],
             overwriteStats: this.toolParams.overwriteStats || false,
             resume: this.toolParams.resume || false,
         };
@@ -116,6 +121,7 @@ export default class VariantStatsIndexOperation extends LitElement {
     onClear() {
         this.toolParams = {
             ...UtilsNew.objectClone(this.DEFAULT_TOOLPARAMS),
+            study: this.toolParams.study || "",
         };
         this.config = this.getDefaultConfig();
     }
@@ -160,6 +166,22 @@ export default class VariantStatsIndexOperation extends LitElement {
             {
                 title: "Configuration Parameters",
                 elements: [
+                    {
+                        title: "Cohort IDs",
+                        type: "custom",
+                        required: true,
+                        display: {
+                            render: toolParams => html `
+                                <catalog-search-autocomplete
+                                    .value="${toolParams?.cohort}"
+                                    .resource="${"COHORT"}"
+                                    .opencgaSession="${this.opencgaSession}"
+                                    .config="${{multiple: true}}"
+                                    @filterChange="${e => this.onFieldChange(e, "cohort")}">
+                                </catalog-search-autocomplete>
+                            `,
+                        },
+                    },
                     {
                         title: "Overwrite Stats",
                         field: "overwriteStats",


### PR DESCRIPTION
This PR includes the required parameter 'cohort' in the variant-stats-index operation, and fixes a bug when an operation is launched.